### PR TITLE
Add bike-specific routing

### DIFF
--- a/pkg/data/build_graph.go
+++ b/pkg/data/build_graph.go
@@ -1,4 +1,4 @@
-// Package data handles fetching OSM data and parsing it into a graph structure
+// Package data handles fetching OSM data and parsing it into a graph structure suitable for bike routing
 package data
 
 import (
@@ -11,12 +11,12 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/model"
 )
 
-// OSMResponse consists of a list of OSMElements
+// OSMResponse consists of a list of OSMElements.
 type OSMResponse struct {
 	Elements []OSMElement `json:"elements"`
 }
 
-// OSMElement represents OSM 'nodes' and 'ways'
+// OSMElement represents OSM 'nodes' and 'ways' with associated tags and coordinates.
 type OSMElement struct {
 	Type  string            `json:"type"` // "node" or "way"
 	ID    int64             `json:"id"`
@@ -26,17 +26,20 @@ type OSMElement struct {
 	Tags  map[string]string `json:"tags,omitempty"`
 }
 
+// FeatureCollection represents a GeoJSON FeatureCollection.
 type FeatureCollection struct {
 	Type     string    `json:"type"`
 	Features []Feature `json:"features"`
 }
 
+// Feature represents a GeoJSON feature with associated properties and geometry.
 type Feature struct {
 	Type       string                 `json:"type"`
 	Properties map[string]interface{} `json:"properties"`
 	Geometry   Geometry               `json:"geometry"`
 }
 
+// Geometry represents the GeoJSON geometry of a feature.
 type Geometry struct {
 	Type        string       `json:"type"`
 	Coordinates [][2]float64 `json:"coordinates"`
@@ -149,6 +152,7 @@ func BuildGraph(filename string) (*model.Graph, error) {
 	return &network, nil
 }
 
+// computeWayWeight computes a weight for an edge by modifying the distance using the tags
 func computeWayWeight(distance float64, tags map[string]string) float64 {
 	highwayPenalty := map[string]float64{
 		"cycleway":    0.5,
@@ -161,9 +165,9 @@ func computeWayWeight(distance float64, tags map[string]string) float64 {
 	}
 	surfacePenalty := map[string]float64{
 		"concrete": 1.0,
-		"asphalt": 1.0,
-		"gravel": 1.5,
-		"dirt": 1.75,
+		"asphalt":  1.0,
+		"gravel":   1.5,
+		"dirt":     1.75,
 	}
 
 	highwayMultiplier, found := highwayPenalty[tags["highway"]]
@@ -183,10 +187,13 @@ func computeWayWeight(distance float64, tags map[string]string) float64 {
 	if tags["bicycle"] == "designated" {
 		bikeFriendlyMultiplier *= 0.9
 	} else if tags["bicycle"] == "yes" || tags["bike"] == "yes" {
-		bikeFriendlyMultiplier *= 0.95
+		bikeFriendlyMultiplier *= 0.9
 	}
 	if tags["motor_vehicle"] == "no" {
 		bikeFriendlyMultiplier *= 0.7
+	}
+	if tags["lcn"] == "yes" {
+		bikeFriendlyMultiplier *= 0.9
 	}
 
 	return distance * highwayMultiplier * surfaceMultiplier * bikeFriendlyMultiplier

--- a/pkg/data/build_graph.go
+++ b/pkg/data/build_graph.go
@@ -3,7 +3,6 @@ package data
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"math"
 	"os"
@@ -124,10 +123,7 @@ func BuildGraph(filename string) (*model.Graph, error) {
 			}
 		}
 	}
-	for j, el := range resp.Elements {
-		if j == 0 {
-			fmt.Printf("%+v", el)
-		}
+	for _, el := range resp.Elements {
 		if el.Type == "way" {
 			for i := 0; i < len(el.Nodes)-1; i++ {
 				fromID := el.Nodes[i]
@@ -155,7 +151,7 @@ func BuildGraph(filename string) (*model.Graph, error) {
 // computeWayWeight computes a weight for an edge by modifying the distance using the tags
 func computeWayWeight(distance float64, tags map[string]string) float64 {
 	highwayPenalty := map[string]float64{
-		"cycleway":    0.5,
+		"cycleway":    0.9,
 		"residential": 1,
 		"tertiary":    1.2,
 		"secondary":   1.5,
@@ -163,26 +159,30 @@ func computeWayWeight(distance float64, tags map[string]string) float64 {
 		"motorway":    math.Inf(1),
 		"trunk":       math.Inf(1),
 	}
-	surfacePenalty := map[string]float64{
-		"concrete": 1.0,
-		"asphalt":  1.0,
-		"gravel":   1.5,
-		"dirt":     1.75,
-	}
+	/*
+		surfacePenalty := map[string]float64{
+			"concrete": 1.0,
+			"asphalt":  1.0,
+			"gravel":   1.5,
+			"dirt":     1.75,
+		}
+	*/
 
 	highwayMultiplier, found := highwayPenalty[tags["highway"]]
 	if !found {
 		highwayMultiplier = 1.5
 	}
 
-	surfaceMultiplier, found := surfacePenalty[tags["surface"]]
-	if !found {
-		surfaceMultiplier = 1.75
-	}
+	/*
+		surfaceMultiplier, found := surfacePenalty[tags["surface"]]
+		if !found {
+			surfaceMultiplier = 1.75
+		}
+	*/
 
 	bikeFriendlyMultiplier := 1.0
 	if tags["cycleway"] != "" {
-		bikeFriendlyMultiplier *= 0.8
+		bikeFriendlyMultiplier *= 0.9
 	}
 	if tags["bicycle"] == "designated" {
 		bikeFriendlyMultiplier *= 0.9
@@ -190,13 +190,18 @@ func computeWayWeight(distance float64, tags map[string]string) float64 {
 		bikeFriendlyMultiplier *= 0.9
 	}
 	if tags["motor_vehicle"] == "no" {
-		bikeFriendlyMultiplier *= 0.7
+		bikeFriendlyMultiplier *= 0.9
 	}
 	if tags["lcn"] == "yes" {
 		bikeFriendlyMultiplier *= 0.9
 	}
 
-	return distance * highwayMultiplier * surfaceMultiplier * bikeFriendlyMultiplier
+	// Do not punish non-cycleways if they are cycle designated
+	if bikeFriendlyMultiplier < 1 && highwayMultiplier > 1 {
+		highwayMultiplier = 1
+	}
+
+	return distance * highwayMultiplier * bikeFriendlyMultiplier
 }
 
 func haversineDistance(lat1, lon1, lat2, lon2 float64) float64 {

--- a/pkg/data/build_graph.go
+++ b/pkg/data/build_graph.go
@@ -2,107 +2,21 @@
 package data
 
 import (
-	"encoding/json"
 	"log"
 	"math"
-	"os"
 
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/model"
 )
 
-// OSMResponse consists of a list of OSMElements.
-type OSMResponse struct {
-	Elements []OSMElement `json:"elements"`
-}
-
-// OSMElement represents OSM 'nodes' and 'ways' with associated tags and coordinates.
-type OSMElement struct {
-	Type  string            `json:"type"` // "node" or "way"
-	ID    int64             `json:"id"`
-	Lat   float64           `json:"lat,omitempty"`   // only nodes
-	Lon   float64           `json:"lon,omitempty"`   // only nodes
-	Nodes []int64           `json:"nodes,omitempty"` // only ways
-	Tags  map[string]string `json:"tags,omitempty"`
-}
-
-// FeatureCollection represents a GeoJSON FeatureCollection.
-type FeatureCollection struct {
-	Type     string    `json:"type"`
-	Features []Feature `json:"features"`
-}
-
-// Feature represents a GeoJSON feature with associated properties and geometry.
-type Feature struct {
-	Type       string                 `json:"type"`
-	Properties map[string]interface{} `json:"properties"`
-	Geometry   Geometry               `json:"geometry"`
-}
-
-// Geometry represents the GeoJSON geometry of a feature.
-type Geometry struct {
-	Type        string       `json:"type"`
-	Coordinates [][2]float64 `json:"coordinates"`
-}
-
-// GetAllGeoJsonData transforms the data into GeoJSON format
-func GetAllGeoJsonData(filename string) ([]byte, error) {
-	resp, err := parseOSMJSON(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	nodeMap := make(map[int64]OSMElement)
-	for _, el := range resp.Elements {
-		if el.Type == "node" {
-			nodeMap[el.ID] = el
-		}
-	}
-
-	var allFeatures []Feature
-	for _, el := range resp.Elements {
-		if el.Type == "way" {
-			var coordinates = [][2]float64{}
-			for _, nodeID := range el.Nodes {
-				var nodeLonLat = [2]float64{}
-				nodeLonLat[0] = nodeMap[nodeID].Lon
-				nodeLonLat[1] = nodeMap[nodeID].Lat
-				coordinates = append(coordinates, nodeLonLat)
-			}
-
-			wayFeature := Feature{
-				Type: "Feature",
-				Properties: map[string]any{
-					"name": el.Tags["name"],
-				},
-				Geometry: Geometry{
-					Type:        "LineString",
-					Coordinates: coordinates,
-				},
-			}
-			allFeatures = append(allFeatures, wayFeature)
-		}
-	}
-
-	featureCollection := FeatureCollection{
-		Type:     "FeatureCollection",
-		Features: allFeatures,
-	}
-
-	jsonData, err := json.MarshalIndent(featureCollection, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.WriteFile("web/edmonton_bike_data_geo.json", jsonData, 0644)
-	if err != nil {
-		log.Printf("Error")
-		return nil, err
-	} else {
-		log.Printf("Success")
-	}
-
-	return jsonData, nil
-}
+const (
+	tagBicycle      = "bicycle"
+	tagBike         = "bike"
+	tagCycleway     = "cycleway"
+	tagHighway      = "highway"
+	tagLCN          = "lcn"
+	tagMotorVehicle = "motor_vehicle"
+	tagOneway       = "one_way"
+)
 
 // BuildGraph reads OSM json data from a file and parses it into a graph structure
 func BuildGraph(filename string) (*model.Graph, error) {
@@ -127,9 +41,13 @@ func BuildGraph(filename string) (*model.Graph, error) {
 		if el.Type == "way" {
 			for i := 0; i < len(el.Nodes)-1; i++ {
 				fromID := el.Nodes[i]
-				fromCoord := network.Nodes[fromID]
+				fromCoord, fromExists := network.Nodes[fromID]
 				toID := el.Nodes[i+1]
-				toCoord := network.Nodes[toID]
+				toCoord, toExists := network.Nodes[toID]
+				if !fromExists || !toExists {
+					log.Printf("Warning: node missing for way %d: %d to %d", el.ID, fromID, toID)
+					continue
+				}
 
 				dist := haversineDistance(fromCoord.Latitude, fromCoord.Longitude, toCoord.Latitude, toCoord.Longitude)
 				weight := computeWayWeight(dist, el.Tags)
@@ -138,10 +56,12 @@ func BuildGraph(filename string) (*model.Graph, error) {
 					To:     toID,
 					Weight: weight,
 				})
-				network.Edges[toID] = append(network.Edges[toID], model.Edge{
-					To:     fromID,
-					Weight: weight,
-				})
+				if el.Tags[tagOneway] != "yes" {
+					network.Edges[toID] = append(network.Edges[toID], model.Edge{
+						To:     fromID,
+						Weight: weight,
+					})
+				}
 			}
 		}
 	}
@@ -160,41 +80,28 @@ func computeWayWeight(distance float64, tags map[string]string) float64 {
 		"trunk":       math.Inf(1),
 	}
 	/*
+		TODO: decide whether to proceed with surface penalties. Not all data is marked with surface
+		// Would need to infer "asphalt" for good bike connections where they are not labeled
+
 		surfacePenalty := map[string]float64{
 			"concrete": 1.0,
 			"asphalt":  1.0,
 			"gravel":   1.5,
 			"dirt":     1.75,
 		}
-	*/
 
-	highwayMultiplier, found := highwayPenalty[tags["highway"]]
-	if !found {
-		highwayMultiplier = 1.5
-	}
-
-	/*
 		surfaceMultiplier, found := surfacePenalty[tags["surface"]]
 		if !found {
 			surfaceMultiplier = 1.75
 		}
 	*/
 
-	bikeFriendlyMultiplier := 1.0
-	if tags["cycleway"] != "" {
-		bikeFriendlyMultiplier *= 0.9
+	highwayMultiplier, found := highwayPenalty[tags[tagHighway]]
+	if !found {
+		highwayMultiplier = 1.5
 	}
-	if tags["bicycle"] == "designated" {
-		bikeFriendlyMultiplier *= 0.9
-	} else if tags["bicycle"] == "yes" || tags["bike"] == "yes" {
-		bikeFriendlyMultiplier *= 0.9
-	}
-	if tags["motor_vehicle"] == "no" {
-		bikeFriendlyMultiplier *= 0.9
-	}
-	if tags["lcn"] == "yes" {
-		bikeFriendlyMultiplier *= 0.9
-	}
+
+	bikeFriendlyMultiplier := computeBikeFriendlyMultiplier(tags)
 
 	// Do not punish non-cycleways if they are cycle designated
 	if bikeFriendlyMultiplier < 1 && highwayMultiplier > 1 {
@@ -204,6 +111,19 @@ func computeWayWeight(distance float64, tags map[string]string) float64 {
 	return distance * highwayMultiplier * bikeFriendlyMultiplier
 }
 
+// computeBikeFriendlyMultiplier computes a multiplier for a way's weight based on the bike characteristics in its tags
+func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
+	bikeFriendlyMultiplier := 1.0
+	if tags[tagCycleway] != "" || tags[tagBicycle] == "designated" || tags[tagMotorVehicle] == "no" {
+		bikeFriendlyMultiplier *= 0.9
+	}
+	if tags[tagBicycle] == "yes" || tags[tagBike] == "yes" || tags[tagLCN] == "yes" {
+		bikeFriendlyMultiplier *= 0.95
+	}
+	return bikeFriendlyMultiplier
+}
+
+// haversineDistance computes the haversine distance between two latitude-longitude coordinate pairs
 func haversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	const earthRadius = 6371000 // meters
 
@@ -222,19 +142,5 @@ func haversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	a := sinDeltaLat*sinDeltaLat + math.Cos(lat1Rad)*math.Cos(lat2Rad)*sinDeltaLon*sinDeltaLon
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
 
-	distance := earthRadius * c
-	return distance
-}
-
-func parseOSMJSON(filename string) (*OSMResponse, error) {
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	var resp OSMResponse
-	err = json.Unmarshal(data, &resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return earthRadius * c
 }

--- a/pkg/data/build_graph.go
+++ b/pkg/data/build_graph.go
@@ -3,6 +3,7 @@ package data
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"math"
 	"os"
@@ -120,7 +121,10 @@ func BuildGraph(filename string) (*model.Graph, error) {
 			}
 		}
 	}
-	for _, el := range resp.Elements {
+	for j, el := range resp.Elements {
+		if j == 0 {
+			fmt.Printf("%+v", el)
+		}
 		if el.Type == "way" {
 			for i := 0; i < len(el.Nodes)-1; i++ {
 				fromID := el.Nodes[i]
@@ -129,19 +133,63 @@ func BuildGraph(filename string) (*model.Graph, error) {
 				toCoord := network.Nodes[toID]
 
 				dist := haversineDistance(fromCoord.Latitude, fromCoord.Longitude, toCoord.Latitude, toCoord.Longitude)
+				weight := computeWayWeight(dist, el.Tags)
 
 				network.Edges[fromID] = append(network.Edges[fromID], model.Edge{
 					To:     toID,
-					Weight: dist,
+					Weight: weight,
 				})
 				network.Edges[toID] = append(network.Edges[toID], model.Edge{
 					To:     fromID,
-					Weight: dist,
+					Weight: weight,
 				})
 			}
 		}
 	}
 	return &network, nil
+}
+
+func computeWayWeight(distance float64, tags map[string]string) float64 {
+	highwayPenalty := map[string]float64{
+		"cycleway":    0.5,
+		"residential": 1,
+		"tertiary":    1.2,
+		"secondary":   1.5,
+		"primary":     2.0,
+		"motorway":    math.Inf(1),
+		"trunk":       math.Inf(1),
+	}
+	surfacePenalty := map[string]float64{
+		"concrete": 1.0,
+		"asphalt": 1.0,
+		"gravel": 1.5,
+		"dirt": 1.75,
+	}
+
+	highwayMultiplier, found := highwayPenalty[tags["highway"]]
+	if !found {
+		highwayMultiplier = 1.5
+	}
+
+	surfaceMultiplier, found := surfacePenalty[tags["surface"]]
+	if !found {
+		surfaceMultiplier = 1.75
+	}
+
+	bikeFriendlyMultiplier := 1.0
+	if tags["cycleway"] != "" {
+		bikeFriendlyMultiplier *= 0.8
+	}
+	if tags["bicycle"] == "designated" {
+		bikeFriendlyMultiplier *= 0.9
+	} else if tags["bicycle"] == "yes" || tags["bike"] == "yes" {
+		bikeFriendlyMultiplier *= 0.95
+	}
+	if tags["motor_vehicle"] == "no" {
+		bikeFriendlyMultiplier *= 0.7
+	}
+
+	return distance * highwayMultiplier * surfaceMultiplier * bikeFriendlyMultiplier
 }
 
 func haversineDistance(lat1, lon1, lat2, lon2 float64) float64 {

--- a/pkg/data/build_graph_test.go
+++ b/pkg/data/build_graph_test.go
@@ -82,7 +82,7 @@ func TestComputeWayWeightBikeLane(t *testing.T) {
 		"motor_vehicle": "no",
 	}
 
-	wantWeight := distance * 0.9 * 0.9 * 0.9 * 0.9
+	wantWeight := distance * 0.9 * 0.9 * 0.95
 	gotWeight := computeWayWeight(distance, tags)
 
 	if math.Abs(gotWeight-wantWeight) > 1e-6 {

--- a/pkg/data/build_graph_test.go
+++ b/pkg/data/build_graph_test.go
@@ -1,12 +1,14 @@
 package data
 
 import (
+	"math"
 	"path/filepath"
 	"testing"
 
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/model"
 )
 
+// BuildGraph:
 func TestBuildGraphSimple(t *testing.T) {
 	input := filepath.Join("testdata", "test_osm_data.json")
 
@@ -67,5 +69,37 @@ func TestBuildGraphSimple(t *testing.T) {
 				t.Errorf("Edge mismatch for id %d at index %d: got %+v, want %+v", id, i, gotEdge, wantEdge)
 			}
 		}
+	}
+}
+
+// computeWayWeight:
+func TestComputeWayWeightBikeLane(t *testing.T) {
+	distance := 10.0
+	tags := map[string]string{
+		"bicycle":       "designated",
+		"highway":       "cycleway",
+		"lcn":           "yes",
+		"motor_vehicle": "no",
+	}
+
+	wantWeight := distance * 0.5 * 1.75 * 0.9 * 0.9 * 0.7
+	gotWeight := computeWayWeight(distance, tags)
+
+	if math.Abs(gotWeight-wantWeight) > 1e-6 {
+		t.Errorf("Wrong weight: got %f, wanted %f", gotWeight, wantWeight)
+	}
+}
+
+func TestComputeWayWeightPoorBikeRoad(t *testing.T) {
+	distance := 5.75
+	tags := map[string]string{
+		"highway": "trunk",
+	}
+
+	wantWeight := distance * math.Inf(1)
+	gotWeight := computeWayWeight(distance, tags)
+
+	if gotWeight != wantWeight {
+		t.Errorf("Wrong weight: got %f, wanted %f", gotWeight, wantWeight)
 	}
 }

--- a/pkg/data/build_graph_test.go
+++ b/pkg/data/build_graph_test.go
@@ -82,7 +82,7 @@ func TestComputeWayWeightBikeLane(t *testing.T) {
 		"motor_vehicle": "no",
 	}
 
-	wantWeight := distance * 0.5 * 1.75 * 0.9 * 0.9 * 0.7
+	wantWeight := distance * 0.9 * 0.9 * 0.9 * 0.9
 	gotWeight := computeWayWeight(distance, tags)
 
 	if math.Abs(gotWeight-wantWeight) > 1e-6 {

--- a/pkg/data/osm_parse.go
+++ b/pkg/data/osm_parse.go
@@ -6,21 +6,6 @@ import (
 	"os"
 )
 
-// OSMResponse consists of a list of OSMElements.
-type OSMResponse struct {
-	Elements []OSMElement `json:"elements"`
-}
-
-// OSMElement represents OSM 'nodes' and 'ways' with associated tags and coordinates.
-type OSMElement struct {
-	Type  string            `json:"type"` // "node" or "way"
-	ID    int64             `json:"id"`
-	Lat   float64           `json:"lat,omitempty"`   // only nodes
-	Lon   float64           `json:"lon,omitempty"`   // only nodes
-	Nodes []int64           `json:"nodes,omitempty"` // only ways
-	Tags  map[string]string `json:"tags,omitempty"`
-}
-
 // FeatureCollection represents a GeoJSON FeatureCollection.
 type FeatureCollection struct {
 	Type     string    `json:"type"`
@@ -100,6 +85,22 @@ func GetAllGeoJsonData(filename string) ([]byte, error) {
 	return jsonData, nil
 }
 
+// OSMResponse consists of a list of OSMElements.
+type OSMResponse struct {
+	Elements []OSMElement `json:"elements"`
+}
+
+// OSMElement represents OSM 'nodes' and 'ways' with associated tags and coordinates.
+type OSMElement struct {
+	Type  string            `json:"type"` // "node" or "way"
+	ID    int64             `json:"id"`
+	Lat   float64           `json:"lat,omitempty"`   // only nodes
+	Lon   float64           `json:"lon,omitempty"`   // only nodes
+	Nodes []int64           `json:"nodes,omitempty"` // only ways
+	Tags  map[string]string `json:"tags,omitempty"`
+}
+
+// parseOSMJSON parses OSM data from a file into the OSMResponse struct
 func parseOSMJSON(filename string) (*OSMResponse, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {

--- a/pkg/data/osm_parse.go
+++ b/pkg/data/osm_parse.go
@@ -1,0 +1,114 @@
+package data
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+)
+
+// OSMResponse consists of a list of OSMElements.
+type OSMResponse struct {
+	Elements []OSMElement `json:"elements"`
+}
+
+// OSMElement represents OSM 'nodes' and 'ways' with associated tags and coordinates.
+type OSMElement struct {
+	Type  string            `json:"type"` // "node" or "way"
+	ID    int64             `json:"id"`
+	Lat   float64           `json:"lat,omitempty"`   // only nodes
+	Lon   float64           `json:"lon,omitempty"`   // only nodes
+	Nodes []int64           `json:"nodes,omitempty"` // only ways
+	Tags  map[string]string `json:"tags,omitempty"`
+}
+
+// FeatureCollection represents a GeoJSON FeatureCollection.
+type FeatureCollection struct {
+	Type     string    `json:"type"`
+	Features []Feature `json:"features"`
+}
+
+// Feature represents a GeoJSON feature with associated properties and geometry.
+type Feature struct {
+	Type       string                 `json:"type"`
+	Properties map[string]interface{} `json:"properties"`
+	Geometry   Geometry               `json:"geometry"`
+}
+
+// Geometry represents the GeoJSON geometry of a feature.
+type Geometry struct {
+	Type        string       `json:"type"`
+	Coordinates [][2]float64 `json:"coordinates"`
+}
+
+// GetAllGeoJsonData transforms the data into GeoJSON format
+func GetAllGeoJsonData(filename string) ([]byte, error) {
+	resp, err := parseOSMJSON(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeMap := make(map[int64]OSMElement)
+	for _, el := range resp.Elements {
+		if el.Type == "node" {
+			nodeMap[el.ID] = el
+		}
+	}
+
+	var allFeatures []Feature
+	for _, el := range resp.Elements {
+		if el.Type == "way" {
+			var coordinates = [][2]float64{}
+			for _, nodeID := range el.Nodes {
+				var nodeLonLat = [2]float64{}
+				nodeLonLat[0] = nodeMap[nodeID].Lon
+				nodeLonLat[1] = nodeMap[nodeID].Lat
+				coordinates = append(coordinates, nodeLonLat)
+			}
+
+			wayFeature := Feature{
+				Type: "Feature",
+				Properties: map[string]any{
+					"name": el.Tags["name"],
+				},
+				Geometry: Geometry{
+					Type:        "LineString",
+					Coordinates: coordinates,
+				},
+			}
+			allFeatures = append(allFeatures, wayFeature)
+		}
+	}
+
+	featureCollection := FeatureCollection{
+		Type:     "FeatureCollection",
+		Features: allFeatures,
+	}
+
+	jsonData, err := json.MarshalIndent(featureCollection, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	err = os.WriteFile("web/edmonton_bike_data_geo.json", jsonData, 0644)
+	if err != nil {
+		log.Printf("Error")
+		return nil, err
+	} else {
+		log.Printf("Success")
+	}
+
+	return jsonData, nil
+}
+
+func parseOSMJSON(filename string) (*OSMResponse, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var resp OSMResponse
+	err = json.Unmarshal(data, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/pkg/data/testdata/test_osm_data.json
+++ b/pkg/data/testdata/test_osm_data.json
@@ -16,7 +16,10 @@
       "type": "way",
       "id": 2,
       "nodes": [0, 1],
-      "tags": {}
+      "tags": {
+        "highway": "residential",
+        "surface": "concrete"
+      }
     }
   ]
 }

--- a/pkg/model/graph.go
+++ b/pkg/model/graph.go
@@ -1,14 +1,17 @@
 package model
 
+// Node represents a location, consisting of a latitude and longitude.
 type Node struct {
 	Latitude, Longitude float64
 }
 
+// Edge represents a connection between nodes, with an associated weight.
 type Edge struct {
 	To     int64
 	Weight float64
 }
 
+// Graph represents a graph structure consisting of nodes and edges between them.
 type Graph struct {
 	Nodes map[int64]Node   // map node ids to nodes
 	Edges map[int64][]Edge // map node ids to lists of edges

--- a/pkg/routing/priority_queue.go
+++ b/pkg/routing/priority_queue.go
@@ -4,28 +4,37 @@ import (
 	"container/heap"
 )
 
+// Item represents a node in the priority queue with an associated distance value.
+// The index field is used internally by the heap to track the item's position.
 type Item struct {
-	NodeID   int64
-	Distance float64
-	index    int
+	NodeID   int64   // Unique identifier of the node
+	Distance float64 // Distance value used for priority ordering
+	index    int     // Index of the item in the heap (maintained by the heap.Interface methods)
 }
 
+// PriorityQueue implements a min-heap priority queue of Items based on their Distance.
 type PriorityQueue []*Item
 
+// Len returns the number of items in the priority queue.
 func (pq PriorityQueue) Len() int {
 	return len(pq)
 }
 
+// Less reports whether the item with index i should sort before the item with index j.
+// Here, Items with smaller Distance have higher priority.
 func (pq PriorityQueue) Less(i, j int) bool {
 	return pq[i].Distance < pq[j].Distance
 }
 
+// Swap swaps the items with indexes i and j and updates their indices accordingly.
 func (pq PriorityQueue) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 	pq[i].index = i
 	pq[j].index = j
 }
 
+// Push adds a new item to the priority queue.
+// This method is called by heap.Push.
 func (pq *PriorityQueue) Push(x any) {
 	n := len(*pq)
 	item := x.(*Item)
@@ -33,15 +42,19 @@ func (pq *PriorityQueue) Push(x any) {
 	*pq = append(*pq, item)
 }
 
+// Pop removes and returns the item with the highest priority (lowest Distance).
+// This method is called by heap.Pop.
 func (pq *PriorityQueue) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
-	item.index = -1
+	item.index = -1 // Mark as removed
 	*pq = old[0 : n-1]
 	return item
 }
 
+// Update modifies the Distance of an item in the priority queue and re-establishes heap order.
+// Use this when the priority of an existing item changes.
 func (pq *PriorityQueue) Update(item *Item, distance float64) {
 	item.Distance = distance
 	heap.Fix(pq, item.index)

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -1,3 +1,5 @@
+// Package routing provides functions to find optimal bike routes using a graph of nodes and edges representing the bike network.
+// Pathfinding is via Dijkstra's algorithm. Start and end locations can be given as coordinates and the nearest node in the network will be used.
 package routing
 
 import (
@@ -7,19 +9,22 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/model"
 )
 
+// squaredEucDistance computes the squared Euclidean distance between two latitude-longitude pairs.
 func squaredEucDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	distLat := lat2 - lat1
 	distLon := lon2 - lon1
 	return distLat*distLat + distLon*distLon
 }
 
+// FindRouteFromCoordinates returns the lowest-cost route between two latitude-longitude pairs.
 func FindRouteFromCoordinates(network *model.Graph, startLatitude, startLongitude, endLatitude, endLongitude float64) (dist float64, path []int64) {
-	startNodeID := findNearestNode(startLatitude, startLongitude, network.Nodes)
-	endNodeID := findNearestNode(endLatitude, endLongitude, network.Nodes)
+	startNodeID := nearestNode(startLatitude, startLongitude, network.Nodes)
+	endNodeID := nearestNode(endLatitude, endLongitude, network.Nodes)
 	return findRoute(network, startNodeID, endNodeID)
 }
 
-func findNearestNode(latitude float64, longitude float64, nodes map[int64]model.Node) (nodeID int64) {
+// nearestNode returns the ID of the closest node in the network to the given latitude-longitude pair.
+func nearestNode(latitude float64, longitude float64, nodes map[int64]model.Node) (nodeID int64) {
 	smallestDistance := math.Inf(1)
 	var smallestNodeID int64 = -1
 	for id, node := range nodes {
@@ -32,8 +37,9 @@ func findNearestNode(latitude float64, longitude float64, nodes map[int64]model.
 	return smallestNodeID
 }
 
+// findRoute returns the lowest-cost route between two nodes using Dijkstra's algorithm.
 func findRoute(network *model.Graph, start, end int64) (dist float64, path []int64) {
-	distMap, prev, found := djikstra(network, start, end)
+	distMap, prev, found := dijkstra(network, start, end)
 	if !found {
 		return math.Inf(1), nil
 	}
@@ -42,12 +48,12 @@ func findRoute(network *model.Graph, start, end int64) (dist float64, path []int
 	return dist, path
 }
 
-// dijkstra finds shortest path from start to goal and stops early when goal is reached.
+// dijkstra finds the shortest path from start to goal and stops early when goal is reached.
 // Returns:
-// - dist: map[nodeID]distance from start to node
+// - dist: map[nodeID]distance from start to each node
 // - prev: map[nodeID]previous node in path for reconstruction
-// - bool: true if goal reachable, false otherwise
-func djikstra(g *model.Graph, start, goal int64) (dist map[int64]float64, prev map[int64]int64, found bool) {
+// - found: true if goal reachable, false otherwise
+func dijkstra(g *model.Graph, start, goal int64) (dist map[int64]float64, prev map[int64]int64, found bool) {
 	dist = make(map[int64]float64)
 	prev = make(map[int64]int64)
 
@@ -92,14 +98,20 @@ func djikstra(g *model.Graph, start, goal int64) (dist map[int64]float64, prev m
 	return dist, prev, found
 }
 
-// reconstructPath returns the shortest path from start to target using prev map.
+// reconstructPath returns the shortest path from start to target using the prev map.
 func reconstructPath(prev map[int64]int64, target int64) []int64 {
 	var path []int64
-	for current, ok := target, true; ok; current, ok = prev[current] {
-		path = append([]int64{current}, path...)
-		if _, found := prev[current]; !found {
+	for current := target; ; {
+		path = append(path, current)
+		prevNode, ok := prev[current]
+		if !ok {
 			break
 		}
+		current = prevNode
+	}
+	// Reverse the path
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
 	}
 	return path
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/routing"
 )
 
+// handleRouteByCoordinates handles HTTP requests to compute a bike route between start and end coordinates.
+// Query parameters: startLatitude, startLongitude, endLatitude, endLongitude (float64).
+// Responds with a GeoJSON LineString representing the line path.
+// Returns HTTP 400 if parameters are missing or invalid.
 func handleRouteByCoordinates(writer http.ResponseWriter, request *http.Request, network *model.Graph) {
 	query := request.URL.Query()
 
@@ -68,39 +72,3 @@ func handleRouteByCoordinates(writer http.ResponseWriter, request *http.Request,
 		log.Printf("handleRoute error encoding json: %v", err)
 	}
 }
-
-/*
-func handleRoute(writer http.ResponseWriter, request *http.Request, network *model.Graph) {
-	query := request.URL.Query()
-
-	startStr := query.Get("start")
-	endStr := query.Get("end")
-
-	startID, _ := strconv.ParseInt(startStr, 10, 64)
-	endID, _ := strconv.ParseInt(endStr, 10, 64)
-	_, pathIds := routing.FindRoute(network, startID, endID)
-
-	var coordinates = [][2]float64{}
-	for _, nodeID := range pathIds {
-		var nodeLonLat = [2]float64{}
-		nodeLonLat[0] = network.Nodes[nodeID].Longitude
-		nodeLonLat[1] = network.Nodes[nodeID].Latitude
-		coordinates = append(coordinates, nodeLonLat)
-	}
-
-	geojson := map[string]any{
-		"type": "Feature",
-		"geometry": map[string]any{
-			"type":        "LineString",
-			"coordinates": coordinates,
-		},
-		"properties": map[string]any{},
-	}
-
-	writer.Header().Set("Content-Type", "application/json")
-	err := json.NewEncoder(writer).Encode(geojson)
-	if err != nil {
-		log.Printf("handleRoute error encoding json: %v", err)
-	}
-}
-*/

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -1,3 +1,4 @@
+// Package server serves the API endpoints for Edmonton Bike Map.
 package server
 
 import (
@@ -6,6 +7,9 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/model"
 )
 
+// RegisterRoutes registers HTTP routes on the given ServeMux.
+// Endpoints:
+// - /api/route: handles routing requests given latitude-longitude coordinates
 func RegisterRoutes(mux *http.ServeMux, network *model.Graph) {
 	mux.HandleFunc("/api/route", func(writer http.ResponseWriter, request *http.Request) {
 		handleRouteByCoordinates(writer, request, network)


### PR DESCRIPTION
Tailors routing for bikes by considering road types and bike friendliness. Adds some tests for the computation of edge weights based on these factors.

Refactor pkg/data/build_graph.go, including separating OSM parsing functionality into pkg/data/osm_parse.go. Adds GoDoc comments for several files.