### PR TITLE
Compute average ratings and capitalize first letter of path surface

### DIFF
--- a/frontend/src/lib/components/ReviewContainer.svelte
+++ b/frontend/src/lib/components/ReviewContainer.svelte
@@ -26,19 +26,9 @@
 	import Review from './Review.svelte';
 	import AddReviewPopup from './AddReviewPopup.svelte';
 	import type { Review as ReviewObj } from '$lib/types';
-	import { fetchReviews } from '$lib/utils/review';
 
-	let { wayId }: { wayId: number } = $props();
+	let { wayId, reviews }: { wayId: number; reviews: ReviewObj[] } = $props();
 	let addReviewActive: boolean = $state(false);
-	let reviews: ReviewObj[] = $state([]);
-
-	async function loadReviews(wayId: number) {
-		reviews = await fetchReviews(wayId);
-	}
-
-	$effect(() => {
-		loadReviews(wayId);
-	});
 </script>
 
 <div id="review-container" class="border-t">
@@ -57,7 +47,6 @@
 		<AddReviewPopup
 			closePopup={() => {
 				addReviewActive = false;
-				loadReviews(wayId);
 			}}
 			{wayId}
 		/>

--- a/frontend/src/lib/components/ReviewContainer.svelte.test.ts
+++ b/frontend/src/lib/components/ReviewContainer.svelte.test.ts
@@ -1,9 +1,12 @@
 import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ReviewContainer from './ReviewContainer.svelte';
+import type { Review } from '$lib/types';
 
-vi.mock('$lib/utils/review', () => ({
-	fetchReviews: vi.fn().mockResolvedValue([
+describe('ReviewContainer.svelte', () => {
+	const wayId = 1;
+
+	const mockReviews: Review[] = [
 		{
 			username: 'Alice',
 			rating: 8,
@@ -11,19 +14,14 @@ vi.mock('$lib/utils/review', () => ({
 			createdAt: '2025-08-18T00:00:00Z',
 			wayID: 1
 		}
-	]),
-	submitReview: vi.fn()
-}));
-
-describe('ReviewContainer.svelte', () => {
-	const wayId = 1;
+	];
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it('loads and displays reviews', async () => {
-		const { getByText } = render(ReviewContainer, { wayId });
+	it('displays passed-in reviews', async () => {
+		const { getByText } = render(ReviewContainer, { props: { wayId, reviews: mockReviews } });
 
 		await waitFor(() => {
 			expect(getByText(/Alice/)).toBeTruthy();
@@ -33,7 +31,7 @@ describe('ReviewContainer.svelte', () => {
 	});
 
 	it('opens AddReviewPopup when Add Review button is clicked', async () => {
-		const { container } = render(ReviewContainer, { wayId });
+		const { container } = render(ReviewContainer, { props: { wayId, reviews: mockReviews } });
 
 		const addButton = container.querySelector<HTMLButtonElement>('#addReviewButton')!;
 		expect(addButton).toBeInTheDocument();
@@ -41,9 +39,6 @@ describe('ReviewContainer.svelte', () => {
 		await fireEvent.click(addButton);
 
 		await waitFor(() => {
-			// The button still exists
-			expect(addButton).toBeInTheDocument();
-
 			const popup = container.querySelector('#addReviewPopup');
 			expect(popup).toBeInTheDocument();
 		});

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -87,7 +87,7 @@
 			</h2>
 		</section>
 
-		<ReviewContainer wayId={way.id} />
+		<ReviewContainer wayId={way.id} {reviews} />
 	</div>
 {/if}
 

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -28,12 +28,24 @@
 	import { wayState } from '$lib/state.svelte';
 	import type { WayFeature } from '$lib/types';
 	import { determineRouteType, determineBicycleRoute } from '$lib/utils/route';
+	import type { Review as ReviewObj } from '$lib/types';
+	import { fetchReviews, computeAverageRating } from '$lib/utils/review';
+	import { capitalizeFirstLetter } from '$lib/utils/helpers';
 
 	let way: WayFeature | null = $derived(wayState.selectedWay);
+	let reviews: ReviewObj[] = $state([]);
+
+	async function loadReviews(wayId: number) {
+		reviews = await fetchReviews(wayId);
+	}
 
 	let sidebarLoaded: boolean = $state(false);
 	$effect(() => {
-		if (way) sidebarLoaded = true;
+		if (way) {
+			loadReviews(way.id);
+			sidebarLoaded = true;
+			console.log(reviews);
+		}
 	});
 
 	let isVisible: boolean = $state(true);
@@ -65,9 +77,15 @@
 				Bicycle Route: <span class="font-normal">{determineBicycleRoute(way.tags)}</span>
 			</h2>
 			<h2 class="font-semibold">
-				Surface: <span class="font-normal">{way.tags.surface ? way.tags.surface : 'Unknown'}</span>
+				Surface: <span class="font-normal"
+					>{way.tags.surface ? capitalizeFirstLetter(way.tags.surface) : 'Unknown'}</span
+				>
 			</h2>
-			<h2 class="font-semibold">Rating: <span class="font-normal">8 / 10</span></h2>
+			<h2 class="font-semibold">
+				Average Rating: <span class="font-normal"
+					>{reviews.length > 0 ? computeAverageRating(reviews) : 'TBD'}</span
+				>
+			</h2>
 		</section>
 
 		<ReviewContainer wayId={way.id} />

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -44,7 +44,6 @@
 		if (way) {
 			loadReviews(way.id);
 			sidebarLoaded = true;
-			console.log(reviews);
 		}
 	});
 
@@ -83,7 +82,7 @@
 			</h2>
 			<h2 class="font-semibold">
 				Average Rating: <span class="font-normal"
-					>{reviews.length > 0 ? computeAverageRating(reviews) : 'TBD'}</span
+					>{reviews.length > 0 ? `${computeAverageRating(reviews)} / 10` : 'TBD'}</span
 				>
 			</h2>
 		</section>

--- a/frontend/src/lib/components/Sidebar.svelte.test.ts
+++ b/frontend/src/lib/components/Sidebar.svelte.test.ts
@@ -2,17 +2,25 @@ import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, beforeEach } from 'vitest';
 import Sidebar from './Sidebar.svelte';
 import { wayState } from '$lib/state.svelte';
+import type { Review } from '$lib/types';
+import * as reviewUtils from '$lib/utils/review';
 
 vi.mock('./ReviewContainer.svelte', () => ({
 	default: () => '<div data-testid="review-container"></div>'
 }));
+
+const mockReviews: Review[] = [
+	{ wayID: 1, username: 'alice', rating: 3, comment: '', createdAt: '2025-09-15' },
+	{ wayID: 1, username: 'bob', rating: 4, comment: '', createdAt: '2025-09-15' },
+	{ wayID: 1, username: 'carol', rating: 5, comment: '', createdAt: '2025-09-15' }
+];
 
 // deterministic mock way
 const mockWay = {
 	id: 1,
 	tags: {
 		name: 'Test Route',
-		surface: 'asphalt',
+		surface: 'Asphalt',
 		highway: 'cycleway',
 		foot: 'yes',
 		bicycle: 'designated',
@@ -23,6 +31,7 @@ const mockWay = {
 describe('Sidebar.svelte', () => {
 	beforeEach(() => {
 		wayState.selectedWay = mockWay;
+		vi.spyOn(reviewUtils, 'fetchReviews').mockResolvedValue(mockReviews);
 	});
 
 	it('renders route info correctly', async () => {
@@ -31,8 +40,8 @@ describe('Sidebar.svelte', () => {
 		await waitFor(() => {
 			expect(getByText('Shared Use Path')).toBeTruthy();
 			expect(getByText('Yes')).toBeTruthy();
-			expect(getByText('asphalt')).toBeTruthy();
-			expect(getByText('8 / 10')).toBeTruthy();
+			expect(getByText('Asphalt')).toBeTruthy();
+			expect(getByText('4 / 10')).toBeTruthy();
 		});
 	});
 

--- a/frontend/src/lib/utils/helpers.ts
+++ b/frontend/src/lib/utils/helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * utils/helpers.ts
+ *
+ * Provides general helper functions.
+ *
+ * Functions:
+ * - capitalizeFirstLetter(str): capitalizes the first letter of the given string
+ *   - Returns a new string
+ */
+
+export function capitalizeFirstLetter(str: string): string {
+	if (!str) return str;
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/frontend/src/lib/utils/review.test.ts
+++ b/frontend/src/lib/utils/review.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { submitReview } from '$lib/utils/review';
+import { submitReview, computeAverageRating } from '$lib/utils/review';
+import type { Review } from '$lib/types';
 
 const apiUrl = import.meta.env.VITE_API_URL;
 

--- a/frontend/src/lib/utils/review.test.ts
+++ b/frontend/src/lib/utils/review.test.ts
@@ -48,3 +48,34 @@ describe('submitReview', () => {
 		await expect(submitReview(reviewData)).rejects.toThrow('Failed to submit review: Bad Request');
 	});
 });
+
+describe('computeAverageRating', () => {
+	it('returns NaN for empty array', () => {
+		const reviews: Review[] = [];
+		expect(computeAverageRating(reviews)).toBeNaN();
+	});
+
+	it('returns the rating itself for single review', () => {
+		const reviews: Review[] = [
+			{ wayID: 1, username: 'alice', rating: 4, comment: 'Nice', createdAt: '2025-09-15' }
+		];
+		expect(computeAverageRating(reviews)).toBe(4);
+	});
+
+	it('calculates average rating rounded to 1 decimal', () => {
+		const reviews: Review[] = [
+			{ wayID: 1, username: 'alice', rating: 3, comment: '', createdAt: '2025-09-15' },
+			{ wayID: 1, username: 'bob', rating: 4, comment: '', createdAt: '2025-09-15' },
+			{ wayID: 1, username: 'carol', rating: 5, comment: '', createdAt: '2025-09-15' }
+		];
+		expect(computeAverageRating(reviews)).toBe(4); // (3+4+5)/3 = 4
+	});
+
+	it('rounds average to 1 decimal for non-integer result', () => {
+		const reviews: Review[] = [
+			{ wayID: 1, username: 'alice', rating: 3, comment: '', createdAt: '2025-09-15' },
+			{ wayID: 1, username: 'bob', rating: 4, comment: '', createdAt: '2025-09-15' }
+		];
+		expect(computeAverageRating(reviews)).toBe(3.5); // (3+4)/2 = 3.5
+	});
+});

--- a/frontend/src/lib/utils/review.ts
+++ b/frontend/src/lib/utils/review.ts
@@ -2,28 +2,33 @@
  * utils/review.ts
  *
  * Purpose:
- * Provides helper functions to fetch and submit user reviews for ways/routes.
+ * Provides helper functions to fetch, submit, and process user reviews for ways/routes.
  *
  * Types:
  * - ReviewData: object with `wayId`, `userId`, `rating`, and optional `comment`
+ * - ReviewObj: type representing a review retrieved from the backend
  * - FetchFn: type alias for a fetch-like function (used for dependency injection/testing)
  *
  * Functions:
  * - fetchReviews(wayId): retrieves all reviews for a given way from the backend
- *     - Returns an array of Review objects
+ *     - Returns an array of ReviewObj
  *     - Returns an empty array on fetch failure
  * - submitReview(reviewData, fetchFn?): sends a new review to the backend
  *     - Throws an error if submission fails
- *     - Returns the created review as JSON
+ *     - Returns nothing (caller handles result)
+ * - computeAverageRating(reviews): computes the average rating of an array of ReviewObj
+ *     - Returns a number rounded to 1 decimal place
+ *     - Returns NaN if the array is empty
  *
  * Behavior:
  * - fetchReviews uses the browser's fetch API to GET /api/reviews
  * - submitReview uses fetch to POST /api/reviews with JSON payload
- * - Errors are handled gracefully and logged in fetchReviews; submitReview throws errors for the caller to handle
+ * - computeAverageRating sums ratings and rounds the average to one decimal
+ * - Errors are logged in fetchReviews; submitReview throws errors for the caller
  *
  * Notes:
  * - Default fetch function is browser fetch, but can be overridden (useful for testing)
- * - Depends on backend endpoints: /api/reviews
+ * - Depends on backend endpoint: /api/reviews
  */
 
 import type { Review as ReviewObj } from '$lib/types';
@@ -60,4 +65,16 @@ export async function submitReview(reviewData: ReviewData, fetchFn: FetchFn = fe
 	if (!res.ok) {
 		throw new Error(`Failed to submit review: ${res.statusText}`);
 	}
+}
+
+export function computeAverageRating(reviews: ReviewObj[]): number {
+	if (reviews.length == 0) return NaN;
+
+	let total = 0;
+	for (const review of reviews) {
+		total += review.rating;
+	}
+
+	const avg = total / reviews.length;
+	return Math.round(avg * 10) / 10;
 }


### PR DESCRIPTION
The sidebar now computes the average rating based on the reviews for that way.

Also capitalized the first letter of the surface e.g. "Surface: Concrete" rather than "Surface: concrete"

Fixes #23 