### PR TITLE
Add time and distance estimates

### DIFF
--- a/backend/pkg/routing/route_finder.go
+++ b/backend/pkg/routing/route_finder.go
@@ -53,7 +53,7 @@ func estimateDistance(path []int64, nodes map[int64]model.Node) float64 {
 	if len(path) < 2 {
 		return 0
 	}
-	
+
 	dist := 0.0
 	for i := 1; i < len(path); i++ {
 		node1, ok1 := nodes[path[i-1]]
@@ -138,11 +138,11 @@ func reconstructPath(prev map[int64]int64, target int64) []int64 {
 
 // planarDistance returns distance in km
 func planarDistance(lat1, lon1, lat2, lon2 float64) float64 {
-    const metersPerDeg = 111320.0 // approximate meters per degree
-    latAvg := (lat1 + lat2) / 2 * math.Pi / 180
+	const metersPerDeg = 111320.0 // approximate meters per degree
+	latAvg := (lat1 + lat2) / 2 * math.Pi / 180
 
-    dx := (lon2 - lon1) * math.Cos(latAvg) * metersPerDeg
-    dy := (lat2 - lat1) * metersPerDeg
+	dx := (lon2 - lon1) * math.Cos(latAvg) * metersPerDeg
+	dy := (lat2 - lat1) * metersPerDeg
 
-    return math.Sqrt(dx*dx + dy*dy) / 1000.0 // convert to km
+	return math.Sqrt(dx*dx+dy*dy) / 1000.0 // convert to km
 }

--- a/backend/pkg/routing/route_finder.go
+++ b/backend/pkg/routing/route_finder.go
@@ -39,13 +39,33 @@ func nearestNode(latitude float64, longitude float64, nodes map[int64]model.Node
 
 // findRoute returns the lowest-cost route between two nodes using Dijkstra's algorithm.
 func findRoute(network *model.Graph, start, end int64) (dist float64, path []int64) {
-	distMap, prev, found := dijkstra(network, start, end)
+	_, prev, found := dijkstra(network, start, end)
 	if !found {
 		return math.Inf(1), nil
 	}
 	path = reconstructPath(prev, end)
-	dist = distMap[end]
+	dist = estimateDistance(path, network.Nodes)
 	return dist, path
+}
+
+// estimateDistance returns the estimated distance of the given path in kilometres
+func estimateDistance(path []int64, nodes map[int64]model.Node) float64 {
+	if len(path) < 2 {
+		return 0
+	}
+	
+	dist := 0.0
+	for i := 1; i < len(path); i++ {
+		node1, ok1 := nodes[path[i-1]]
+		node2, ok2 := nodes[path[i]]
+		if !ok1 || !ok2 {
+			panic("estimateDistance: node ID not found in graph")
+		}
+		segDist := planarDistance(node1.Latitude, node1.Longitude, node2.Latitude, node2.Longitude)
+		dist += segDist
+	}
+
+	return dist
 }
 
 // dijkstra finds the shortest path from start to goal and stops early when goal is reached.
@@ -114,4 +134,15 @@ func reconstructPath(prev map[int64]int64, target int64) []int64 {
 		path[i], path[j] = path[j], path[i]
 	}
 	return path
+}
+
+// planarDistance returns distance in km
+func planarDistance(lat1, lon1, lat2, lon2 float64) float64 {
+    const metersPerDeg = 111320.0 // approximate meters per degree
+    latAvg := (lat1 + lat2) / 2 * math.Pi / 180
+
+    dx := (lon2 - lon1) * math.Cos(latAvg) * metersPerDeg
+    dy := (lat2 - lat1) * metersPerDeg
+
+    return math.Sqrt(dx*dx + dy*dy) / 1000.0 // convert to km
 }

--- a/backend/pkg/routing/routing_test.go
+++ b/backend/pkg/routing/routing_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/pkg/model"
 )
 
+// pathPlanarDistance sums planarDistance over the path using the provided nodes.
+func pathPlanarDistance(path []int64, nodes map[int64]model.Node) float64 {
+    if len(path) < 2 {
+        return 0
+    }
+    total := 0.0
+    for i := 1; i < len(path); i++ {
+        n1 := nodes[path[i-1]]
+        n2 := nodes[path[i]]
+        total += planarDistance(n1.Latitude, n1.Longitude, n2.Latitude, n2.Longitude)
+    }
+    return total
+}
+
 func buildTestGraph() *model.Graph {
 	nodes := map[int64]model.Node{
 		1: {Latitude: 0, Longitude: 0},
@@ -83,13 +97,12 @@ func TestFindRoute(t *testing.T) {
 
 	tests := []struct {
 		start, end int64
-		wantDist   float64
 		wantPaths  [][]int64
 		wantFound  bool
 	}{
-		{1, 4, 4.0, [][]int64{{1, 4}, {1, 2, 3, 4}}, true},
-		{4, 1, math.Inf(1), nil, false},
-		{2, 2, 0, [][]int64{{2}}, true},
+		{1, 4, [][]int64{{1, 4}, {1, 2, 3, 4}}, true},
+		{4, 1, nil, false},
+		{2, 2, [][]int64{{2}}, true},
 	}
 
 	for _, tt := range tests {
@@ -107,8 +120,9 @@ func TestFindRoute(t *testing.T) {
 			continue
 		}
 
-		if math.Abs(dist-tt.wantDist) > 1e-9 {
-			t.Errorf("findRoute(%d, %d): dist = %f; want %f", tt.start, tt.end, dist, tt.wantDist)
+		expectedDist := pathPlanarDistance(path, graph.Nodes)
+		if math.Abs(dist-expectedDist) > 1e-9 {
+			t.Errorf("findRoute(%d, %d): dist = %f; want %f", tt.start, tt.end, dist, expectedDist)
 		}
 
 		matches := false
@@ -132,6 +146,7 @@ func TestFindRoute(t *testing.T) {
 		}
 	}
 }
+
 
 func TestDijkstra(t *testing.T) {
 	graph := buildTestGraph()
@@ -232,14 +247,12 @@ func TestFindRouteFromCoordinates(t *testing.T) {
 	tests := []struct {
 		startLat, startLon float64
 		endLat, endLon     float64
-		wantDist           float64
 		wantPaths          [][]int64
 		wantFound          bool
 	}{
 		{
 			startLat: 0, startLon: 0,
-			endLat: 1, endLon: 0,
-			wantDist: 4.0,
+			endLat:   1, endLon: 0,
 			wantPaths: [][]int64{
 				{1, 4},
 				{1, 2, 3, 4},
@@ -248,15 +261,13 @@ func TestFindRouteFromCoordinates(t *testing.T) {
 		},
 		{
 			startLat: 1, startLon: 0,
-			endLat: 0, endLon: 0,
-			wantDist:  math.Inf(1),
+			endLat:   0, endLon: 0,
 			wantPaths: nil,
 			wantFound: false,
 		},
 		{
 			startLat: 0, startLon: 1,
-			endLat: 0, endLon: 1,
-			wantDist: 0,
+			endLat:   0, endLon: 1,
 			wantPaths: [][]int64{
 				{2},
 			},
@@ -281,9 +292,10 @@ func TestFindRouteFromCoordinates(t *testing.T) {
 			continue
 		}
 
-		if math.Abs(dist-tt.wantDist) > 1e-9 {
+		expectedDist := pathPlanarDistance(path, graph.Nodes)
+		if math.Abs(dist-expectedDist) > 1e-9 {
 			t.Errorf("FindRouteFromCoordinates(%v,%v -> %v,%v): dist = %f; want %f",
-				tt.startLat, tt.startLon, tt.endLat, tt.endLon, dist, tt.wantDist)
+				tt.startLat, tt.startLon, tt.endLat, tt.endLon, dist, expectedDist)
 		}
 
 		matches := false

--- a/backend/pkg/routing/routing_test.go
+++ b/backend/pkg/routing/routing_test.go
@@ -9,16 +9,16 @@ import (
 
 // pathPlanarDistance sums planarDistance over the path using the provided nodes.
 func pathPlanarDistance(path []int64, nodes map[int64]model.Node) float64 {
-    if len(path) < 2 {
-        return 0
-    }
-    total := 0.0
-    for i := 1; i < len(path); i++ {
-        n1 := nodes[path[i-1]]
-        n2 := nodes[path[i]]
-        total += planarDistance(n1.Latitude, n1.Longitude, n2.Latitude, n2.Longitude)
-    }
-    return total
+	if len(path) < 2 {
+		return 0
+	}
+	total := 0.0
+	for i := 1; i < len(path); i++ {
+		n1 := nodes[path[i-1]]
+		n2 := nodes[path[i]]
+		total += planarDistance(n1.Latitude, n1.Longitude, n2.Latitude, n2.Longitude)
+	}
+	return total
 }
 
 func buildTestGraph() *model.Graph {
@@ -147,7 +147,6 @@ func TestFindRoute(t *testing.T) {
 	}
 }
 
-
 func TestDijkstra(t *testing.T) {
 	graph := buildTestGraph()
 
@@ -252,7 +251,7 @@ func TestFindRouteFromCoordinates(t *testing.T) {
 	}{
 		{
 			startLat: 0, startLon: 0,
-			endLat:   1, endLon: 0,
+			endLat: 1, endLon: 0,
 			wantPaths: [][]int64{
 				{1, 4},
 				{1, 2, 3, 4},
@@ -261,13 +260,13 @@ func TestFindRouteFromCoordinates(t *testing.T) {
 		},
 		{
 			startLat: 1, startLon: 0,
-			endLat:   0, endLon: 0,
+			endLat: 0, endLon: 0,
 			wantPaths: nil,
 			wantFound: false,
 		},
 		{
 			startLat: 0, startLon: 1,
-			endLat:   0, endLon: 1,
+			endLat: 0, endLon: 1,
 			wantPaths: [][]int64{
 				{2},
 			},

--- a/backend/pkg/server/handlers/route.go
+++ b/backend/pkg/server/handlers/route.go
@@ -44,7 +44,7 @@ func (h *RealHandlers) HandleRouteByCoordinates() http.HandlerFunc {
 			return
 		}
 
-		_, pathIds := h.Router.FindRouteFromCoordinates(h.Network, startLatitude, startLongitude, endLatitude, endLongitude)
+		dist, pathIds := h.Router.FindRouteFromCoordinates(h.Network, startLatitude, startLongitude, endLatitude, endLongitude)
 
 		var coordinates = [][2]float64{}
 		for _, nodeID := range pathIds {
@@ -60,7 +60,9 @@ func (h *RealHandlers) HandleRouteByCoordinates() http.HandlerFunc {
 				"type":        "LineString",
 				"coordinates": coordinates,
 			},
-			"properties": map[string]any{},
+			"properties": map[string]any{
+				"distance_km": dist,
+			},
 		}
 
 		writer.Header().Set("Content-Type", "application/json")

--- a/backend/pkg/server/handlers/route_test.go
+++ b/backend/pkg/server/handlers/route_test.go
@@ -41,6 +41,7 @@ func TestHandleRouteByCoordinates(t *testing.T) {
 		url             string
 		wantStatus      int
 		wantCoordinates [][2]float64
+		wantDistance    float64
 	}{
 		{
 			name:       "Valid request 1",
@@ -51,6 +52,7 @@ func TestHandleRouteByCoordinates(t *testing.T) {
 				{-113.6, 53.6},
 				{-113.7, 53.7},
 			},
+			wantDistance: 10.5,
 		},
 		{
 			name:       "Valid request 2",
@@ -61,6 +63,7 @@ func TestHandleRouteByCoordinates(t *testing.T) {
 				{-113.6, 53.6},
 				{-113.7, 53.7},
 			},
+			wantDistance: 10.5,
 		},
 		{
 			name:       "Missing parameter",
@@ -84,7 +87,6 @@ func TestHandleRouteByCoordinates(t *testing.T) {
 			resp := w.Result()
 			defer func() {
 				if err := resp.Body.Close(); err != nil {
-					// Log or handle error
 					log.Printf("failed to close response body: %v", err)
 				}
 			}()
@@ -128,6 +130,12 @@ func TestHandleRouteByCoordinates(t *testing.T) {
 					if coord[0] != wantCoord[0] || coord[1] != wantCoord[1] {
 						t.Errorf("coordinate %d = %v; want %v", i, coord, wantCoord)
 					}
+				}
+
+				if dist, ok := geojson.Properties["distance_km"]; !ok {
+					t.Errorf("expected distance_km property but not found")
+				} else if dist.(float64) != tt.wantDistance {
+					t.Errorf("unexpected distance_km: got %v, want %v", dist, tt.wantDistance)
 				}
 			}
 		})

--- a/frontend/src/lib/components/Map.svelte
+++ b/frontend/src/lib/components/Map.svelte
@@ -40,7 +40,7 @@
 	import { loadLeaflet } from '$lib/map/loadLeaflet';
 	import { findRoute } from '$lib/map/mapActions';
 
-  const apiUrl = import.meta.env.VITE_API_URL;
+	const apiUrl = import.meta.env.VITE_API_URL;
 
 	let mapInstance: InstanceType<typeof import('$lib/map/LeafletMap').LeafletMap> | null = null;
 	const allWaysEndpoint = `${apiUrl}/api/all-ways`;
@@ -158,4 +158,17 @@
 			Reset
 		</button>
 	</div>
+
+	<style>
+		.distance-control,
+		.time-control {
+			background-color: rgba(255, 255, 255, 0.9);
+			padding: 0.5rem 1rem;
+			border-radius: 0.5rem;
+			box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+			font-size: 0.875rem;
+			font-weight: 500;
+			text-align: center;
+		}
+	</style>
 </div>

--- a/frontend/src/lib/map/LeafletMap.ts
+++ b/frontend/src/lib/map/LeafletMap.ts
@@ -61,6 +61,8 @@ export class LeafletMap {
 	private endMarker: Marker | null = null;
 	private routeLayer: GeoJSON | null = null;
 	private infoLayer: GeoJSON | null = null;
+	private distanceControl: L.Control | null = null;
+	private timeControl: L.Control | null = null;
 
 	constructor(L: typeof import('leaflet')) {
 		this.L = L;
@@ -188,12 +190,38 @@ export class LeafletMap {
 		if (bounds.isValid()) {
 			this.map.fitBounds(bounds);
 		}
+
+		const feature = geojson as GeoJSON.Feature;
+		const distance = feature.properties?.['distance_km'];
+		// Add distance control
+		this.distanceControl = new (this.L.Control.extend({
+			onAdd: (map: LeafletMapType) => {
+				const div = this.L.DomUtil.create('div', 'distance-control') as HTMLDivElement;
+				div.innerHTML = `Distance: ${distance.toFixed(2)} km`;
+				return div;
+			}
+		}))({ position: 'topright' });
+		this.distanceControl.addTo(this.map);
+		// Add time control
+		const avgSpeedKmh = 20; // commuter average speed
+		const timeH = distance / avgSpeedKmh;
+		const timeMin = Math.round(timeH * 60);
+		this.timeControl = new (this.L.Control.extend({
+			onAdd: (map: LeafletMapType) => {
+				const div = this.L.DomUtil.create('div', 'time-control') as HTMLDivElement;
+				div.innerHTML = `Estimated time: ${timeMin} min`;
+				return div;
+			}
+		}))({ position: 'topright' });
+		this.timeControl.addTo(this.map);
 	}
 
 	removeRouteLayer(): void {
 		if (this.routeLayer) {
 			this.map.removeLayer(this.routeLayer);
 			this.routeLayer = null;
+			this.distanceControl?.remove();
+			this.distanceControl = null;
 		}
 	}
 


### PR DESCRIPTION
When a route is displayed. distance (km) and time (minutes) estimates for that route are displayed in the top right corner of the map. Currently the time estimate simply assumes an average cycling speed of 20 km/hr and applies that to the distance. There are possibilities for more refined estimates.

Resolves issue #19. Added additional issues for some enhancements to this feature.