### PR TITLE
ci: remove push triggers from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - master
   pull_request:
     branches:
       - main


### PR DESCRIPTION
CI currently runs on all pushes to main, such as merging in a pull request. But CI has already run on that pull request before it is merged, so this is unnecessary.