### PR TITLE
ci: switch from PAT to GITHUB_TOKEN for ci/cd

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -39,7 +43,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker image
         run: docker push $IMAGE_NAME:$IMAGE_TAG
@@ -52,7 +56,7 @@ jobs:
           ssh-keyscan -H ${{ secrets.VPS_IP }} >> ~/.ssh/known_hosts
 
       - name: Run backend playbook
-        run: ansible-playbook backend.yml -i inventory.ini --private-key ~/.ssh/id_rsa -e "ghcr_pat=${{ secrets.GHCR_PAT }}"
+        run: ansible-playbook backend.yml -i inventory.ini --private-key ~/.ssh/id_rsa -e "ghcr_pat=${{ secrets.GITHUB_TOKEN }}"
         env:
           ANSIBLE_HOST_KEY_CHECKING: "False"
           LE_EMAIL: ${{ secrets.LE_EMAIL }}


### PR DESCRIPTION
CI/CD is failing to authenticate, likely due to expiry of my personal access token. Switch to using the built in GITHUB_TOKEN instead which is recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication mechanism to enhance security and streamline deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->