### PR TITLE
fix: remove required from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,6 @@ body:
       label: Summary
       description: A short description of the bug
       placeholder: "Example: Login fails when password contains special characters"
-      required: true
 
   - type: textarea
     id: steps
@@ -21,21 +20,18 @@ body:
       label: Steps to Reproduce
       description: Step-by-step instructions to reproduce the issue
       placeholder: "1. Go to ...\n2. Click ...\n3. Observe ..."
-      required: true
 
   - type: textarea
     id: expected
     attributes:
       label: Expected Behavior
       placeholder: "What you expected to happen"
-      required: true
 
   - type: textarea
     id: actual
     attributes:
       label: Actual Behavior
       placeholder: "What actually happened"
-      required: true
 
   - type: input
     id: environment

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,28 +8,24 @@ body:
     attributes:
       label: Summary
       description: A short description of the requested feature or enhancement
-      required: true
 
   - type: textarea
     id: motivation
     attributes:
       label: Motivation
       description: Why is this feature or enhancement useful or needed?
-      required: true
 
   - type: textarea
     id: proposal
     attributes:
       label: Proposed Solution
       description: How should this feature or enhancement work?
-      required: false
 
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives Considered
       description: Any alternative solutions or approaches?
-      required: false
 
   - type: dropdown
     id: label_choice
@@ -39,4 +35,3 @@ body:
       options:
         - feature
         - enhancement
-      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -8,18 +8,15 @@ body:
     attributes:
       label: Summary
       description: What code or module needs refactoring?
-      required: true
 
   - type: textarea
     id: motivation
     attributes:
       label: Motivation
       description: Why should this be refactored or updated?
-      required: false
 
   - type: textarea
     id: approach
     attributes:
       label: Proposed Approach
       description: How do you plan to refactor or improve it?
-      required: false


### PR DESCRIPTION
Remove 'required' lines from issue templates which is preventing github from using them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub issue submission templates to make all fields optional rather than required. This applies to bug reports, feature requests, and refactoring proposals. Users now have greater flexibility when submitting issues and are no longer required to complete every field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->