### PR TITLE
chore: add makefile in subdirs that defers to parent

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,5 @@
+ROOT := ..
+
+.PHONY: % 
+%:
+	$(MAKE) -C $(ROOT) $@

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,5 @@
+ROOT := ..
+
+.PHONY: % 
+%:
+	$(MAKE) -C $(ROOT) $@

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,0 +1,5 @@
+ROOT := ..
+
+.PHONY: % 
+%:
+	$(MAKE) -C $(ROOT) $@


### PR DESCRIPTION
Add Makefiles to frontend/, backend/, e2e/ to gain access to parent make commands from these directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined build configuration across backend, e2e, and frontend so build invocations from those subprojects now forward to the top-level build; results in more consistent, simpler build behavior for local development and CI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->