### PR TITLE
fix: restore review_ways after updates

### DIFF
--- a/backend/internal/models/review.go
+++ b/backend/internal/models/review.go
@@ -3,6 +3,7 @@ package models
 import "time"
 
 type Review struct {
+	ID        int64
 	WayIDs    []int64
 	UserID    int64
 	Rating    int

--- a/backend/internal/repository/txrepo/review_tx.go
+++ b/backend/internal/repository/txrepo/review_tx.go
@@ -44,22 +44,95 @@ func (r *TxReviewRepository) CreateReview(review *models.Review) error {
 		return fmt.Errorf("user already reviewed one or more of these ways")
 	}
 
-	insertReview := `
-		INSERT INTO reviews (
-			user_id,
-			rating,
-			comment
-		) VALUES ($1, $2, $3)
-		RETURNING id
-	`
-	var reviewID int64
-	if err := r.Tx.QueryRow(insertReview, review.UserID, review.Rating, review.Comment).Scan(&reviewID); err != nil {
-		return err
+	var (
+		insertReview string
+		reviewID     int64
+	)
+	if review.CreatedAt.IsZero() {
+		insertReview = `
+			INSERT INTO reviews (
+				user_id,
+				rating,
+				comment
+			) VALUES ($1, $2, $3)
+			RETURNING id
+		`
+		if err := r.Tx.QueryRow(insertReview, review.UserID, review.Rating, review.Comment).Scan(&reviewID); err != nil {
+			return err
+		}
+	} else {
+		insertReview = `
+			INSERT INTO reviews (
+				user_id,
+				rating,
+				comment,
+				created_at
+			) VALUES ($1, $2, $3, $4)
+			RETURNING id
+		`
+		if err := r.Tx.QueryRow(insertReview, review.UserID, review.Rating, review.Comment, review.CreatedAt).Scan(&reviewID); err != nil {
+			return err
+		}
 	}
 
 	linkStmt := `INSERT INTO review_ways (review_id, way_id) VALUES ($1, $2)`
 	for _, wayID := range review.WayIDs {
 		if _, err := r.Tx.Exec(linkStmt, reviewID, wayID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateReviewWithID inserts a review with a specified ID (used during data rebuilds)
+// and links it to ways within the transaction. If CreatedAt is provided (non-zero), it
+// is preserved; otherwise the default timestamp is used.
+func (r *TxReviewRepository) CreateReviewWithID(review *models.Review) error {
+	if review == nil {
+		return fmt.Errorf("nil review")
+	}
+	if review.ID == 0 {
+		return fmt.Errorf("missing review ID")
+	}
+	if len(review.WayIDs) == 0 {
+		return fmt.Errorf("review must include at least one way ID")
+	}
+
+	// Prevent duplicate reviews by the same user for any of the provided ways
+	var exists int
+	dupQuery := `
+		SELECT COUNT(1)
+		FROM reviews r
+		JOIN review_ways rw ON rw.review_id = r.id
+		WHERE r.user_id = $1 AND rw.way_id = ANY($2)
+	`
+	if err := r.Tx.QueryRow(dupQuery, review.UserID, pq.Array(review.WayIDs)).Scan(&exists); err != nil {
+		return err
+	}
+	if exists > 0 {
+		return fmt.Errorf("user already reviewed one or more of these ways")
+	}
+
+	// Insert explicit ID and optional created_at
+	if review.CreatedAt.IsZero() {
+		if _, err := r.Tx.Exec(`
+			INSERT INTO reviews (id, user_id, rating, comment)
+			VALUES ($1, $2, $3, $4)
+		`, review.ID, review.UserID, review.Rating, review.Comment); err != nil {
+			return err
+		}
+	} else {
+		if _, err := r.Tx.Exec(`
+			INSERT INTO reviews (id, user_id, rating, comment, created_at)
+			VALUES ($1, $2, $3, $4, $5)
+		`, review.ID, review.UserID, review.Rating, review.Comment, review.CreatedAt); err != nil {
+			return err
+		}
+	}
+
+	linkStmt := `INSERT INTO review_ways (review_id, way_id) VALUES ($1, $2)`
+	for _, wayID := range review.WayIDs {
+		if _, err := r.Tx.Exec(linkStmt, review.ID, wayID); err != nil {
 			return err
 		}
 	}
@@ -162,7 +235,13 @@ func (r *TxReviewRepository) insertBatch(reviews []models.Review) error {
 	// Re-implement batch insert via repeated CreateReview calls for clarity.
 	for i := range reviews {
 		rev := reviews[i]
-		if err := r.CreateReview(&rev); err != nil {
+		var err error
+		if rev.ID > 0 {
+			err = r.CreateReviewWithID(&rev)
+		} else {
+			err = r.CreateReview(&rev)
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/backend/internal/updater/update.go
+++ b/backend/internal/updater/update.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"database/sql"
 	"log"
+	"time"
 
 	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
 	"github.com/ellismcdougald/edmonton-bike-map/internal/repository/txrepo"
@@ -55,11 +56,28 @@ func UpdateDatabase(db *sql.DB, osmResp *OSMResponse) error {
 	}
 	log.Printf("Inserted %d reviews", len(validReviews))
 
+	// Ensure reviews.id sequence is set past the max id to avoid conflicts on future inserts
+	if err := adjustReviewIDSequence(tx); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	log.Print("Database update committed successfully")
 	return nil
+}
+
+// adjustReviewIDSequence sets the reviews.id sequence to the current max(id)
+// to ensure subsequent inserts without explicit IDs do not conflict.
+func adjustReviewIDSequence(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+		SELECT setval(
+			pg_get_serial_sequence('reviews', 'id'),
+			COALESCE((SELECT MAX(id) FROM reviews), 0)
+		)
+	`)
+	return err
 }
 
 // snapshotExistingReviews captures all reviews and their associated way IDs in the current DB state.
@@ -71,11 +89,14 @@ func snapshotExistingReviews(tx *sql.Tx) ([]models.Review, error) {
 			r.user_id,
 			r.rating,
 			r.comment,
+			r.created_at,
+			u.username,
 			COALESCE(array_agg(rw.way_id ORDER BY rw.way_id)
 					 FILTER (WHERE rw.way_id IS NOT NULL), '{}') AS way_ids
 		FROM reviews r
 		LEFT JOIN review_ways rw ON rw.review_id = r.id
-		GROUP BY r.id, r.user_id, r.rating, r.comment;
+		LEFT JOIN users u ON r.user_id = u.id
+		GROUP BY r.id, r.user_id, r.rating, r.comment, r.created_at, u.username;
 	`
 
 	rows, err := tx.Query(query)
@@ -91,20 +112,25 @@ func snapshotExistingReviews(tx *sql.Tx) ([]models.Review, error) {
 	var out []models.Review
 	for rows.Next() {
 		var (
-			reviewID int64
-			userID   int64
-			rating   int
-			comment  string
-			wayIDs   pq.Int64Array
+			reviewID  int64
+			userID    int64
+			rating    int
+			comment   string
+			createdAt time.Time
+			username  string
+			wayIDs    pq.Int64Array
 		)
-		if err := rows.Scan(&reviewID, &userID, &rating, &comment, &wayIDs); err != nil {
+		if err := rows.Scan(&reviewID, &userID, &rating, &comment, &createdAt, &username, &wayIDs); err != nil {
 			return nil, err
 		}
 		out = append(out, models.Review{
-			WayIDs:  []int64(wayIDs),
-			UserID:  userID,
-			Rating:  rating,
-			Comment: comment,
+			ID:        reviewID,
+			WayIDs:    []int64(wayIDs),
+			UserID:    userID,
+			Rating:    rating,
+			Comment:   comment,
+			CreatedAt: createdAt,
+			Username:  username,
 		})
 	}
 	if err := rows.Err(); err != nil {


### PR DESCRIPTION
`review_ways` was being affected by ways being cleared when updating the database, causing the updater to fail on deployment. This saves and restores review_ways so that the database can be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database update flow to preserve and restore existing reviews when rebuilding data.
  * Prune review links to removed items so only valid associations are kept.
  * Restore explicit review IDs and timestamps when reimporting to avoid losing origin data.
  * Reset ID sequencing after restoration to prevent future ID conflicts.
  * Prevent duplicate review associations on insert.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->