### PR TITLE
feat(routing): tweak routing weight multipliers and some routing style improvements

### DIFF
--- a/backend/internal/domain/network/multipliers.go
+++ b/backend/internal/domain/network/multipliers.go
@@ -80,6 +80,9 @@ func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
 	if tags[tagMTB] != "" {
 		bikeFriendlyMultiplier *= 1.2
 	}
+	if tags["highway"] == "steps" {
+		bikeFriendlyMultiplier *= 2
+	}
 	return bikeFriendlyMultiplier
 }
 

--- a/backend/internal/domain/network/multipliers.go
+++ b/backend/internal/domain/network/multipliers.go
@@ -78,10 +78,10 @@ func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
 		bikeFriendlyMultiplier *= 3
 	}
 	if tags[tagMTB] != "" {
-		bikeFriendlyMultiplier *= 1.2
+		bikeFriendlyMultiplier *= 10
 	}
 	if tags["highway"] == "steps" {
-		bikeFriendlyMultiplier *= 2
+		bikeFriendlyMultiplier *= 5
 	}
 	return bikeFriendlyMultiplier
 }

--- a/backend/internal/domain/network/multipliers.go
+++ b/backend/internal/domain/network/multipliers.go
@@ -13,11 +13,13 @@ const (
 	tagLCN          = "lcn"
 	tagMotorVehicle = "motor_vehicle"
 	tagOneway       = "one_way"
+	tagMTB          = "mtb:scale:imba"
 )
 
 // computeTagsMultiplier computes a multiplier for a way's weight based on its tags
 func computeTagsMultiplier(tags map[string]string) float64 {
 	highwayMultiplier := computeHighwayMultiplier(tags["highway"])
+	surfaceMultiplier := computeSurfaceMultiplier(tags["surface"])
 	bikeFriendlyMultiplier := computeBikeFriendlyMultiplier(tags)
 
 	// Do not punish non-cycleways if they are cycle designated
@@ -25,7 +27,7 @@ func computeTagsMultiplier(tags map[string]string) float64 {
 		highwayMultiplier = 1
 	}
 
-	return highwayMultiplier * bikeFriendlyMultiplier
+	return highwayMultiplier * surfaceMultiplier * bikeFriendlyMultiplier
 }
 
 // computeHighwayMultiplier computes a multiplier based on the highway tag
@@ -47,6 +49,22 @@ func computeHighwayMultiplier(highwayTag string) float64 {
 	return highwayMultiplier
 }
 
+// computeSurfaceMultiplier computes a multiplier based on the surface tag
+func computeSurfaceMultiplier(surfaceTag string) float64 {
+	surfacePenalty := map[string]float64{
+		"asphalt": 0.95,
+		"gravel":  1.1,
+		"dirt":    1.2,
+	}
+
+	surfaceMultiplier, found := surfacePenalty[surfaceTag]
+	if !found {
+		surfaceMultiplier = 1.0
+	}
+
+	return surfaceMultiplier
+}
+
 // computeBikeFriendlyMultiplier computes a multiplier for a way's weight based on the bike characteristics in its tags
 func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
 	bikeFriendlyMultiplier := 1.0
@@ -58,6 +76,9 @@ func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
 	}
 	if tags[tagBicycle] == "no" || tags[tagBike] == "no" {
 		bikeFriendlyMultiplier *= 3
+	}
+	if tags[tagMTB] != "" {
+		bikeFriendlyMultiplier *= 1.2
 	}
 	return bikeFriendlyMultiplier
 }

--- a/backend/internal/domain/network/multipliers.go
+++ b/backend/internal/domain/network/multipliers.go
@@ -56,6 +56,9 @@ func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
 	if tags[tagBicycle] == "yes" || tags[tagBike] == "yes" || tags[tagLCN] == "yes" {
 		bikeFriendlyMultiplier *= 0.95
 	}
+	if tags[tagBicycle] == "no" || tags[tagBike] == "no" {
+		bikeFriendlyMultiplier *= 3
+	}
 	return bikeFriendlyMultiplier
 }
 

--- a/frontend/src/lib/map/LeafletMap.test.ts
+++ b/frontend/src/lib/map/LeafletMap.test.ts
@@ -198,7 +198,7 @@ describe('LeafletMap.loadRouteLayer', () => {
 
 		const calls = (L as any)._geoJsonCalls;
 		const featureLayer = calls[0].layer._features[0].layer;
-		expect(featureLayer._popupContent).toContain('<strong>Shortest Route</strong>');
+		expect(featureLayer._popupContent).toContain('<strong>Best Route</strong>');
 		expect(featureLayer._popupContent).toContain('Distance: 5.25 km');
 		expect(featureLayer._popupContent).toContain('Time: 15 min');
 	});

--- a/frontend/src/lib/map/LeafletMap.ts
+++ b/frontend/src/lib/map/LeafletMap.ts
@@ -213,7 +213,7 @@ export class LeafletMap {
 			let popupContent = '<strong>Route';
 			if (routeIndex !== undefined) {
 				if (routeIndex === 1) {
-					popupContent = '<strong>Shortest Route';
+					popupContent = '<strong>Best Route';
 				} else {
 					popupContent += ` ${routeIndex}`;
 				}

--- a/frontend/src/lib/map/LeafletMap.ts
+++ b/frontend/src/lib/map/LeafletMap.ts
@@ -316,7 +316,7 @@ export class LeafletMap {
 				div.innerHTML = `Distance: ${distanceNum.toFixed(2)} km`;
 				return div;
 			}
-		}))({ position: 'topright' });
+		}))({ position: 'bottomleft' });
 		this.distanceControl.addTo(this.map);
 
 		// Add time control
@@ -326,7 +326,7 @@ export class LeafletMap {
 				div.innerHTML = `Estimated time: ${timeMin} min`;
 				return div;
 			}
-		}))({ position: 'topright' });
+		}))({ position: 'bottomleft' });
 		this.timeControl.addTo(this.map);
 	}
 

--- a/frontend/src/lib/map/LeafletMap.ts
+++ b/frontend/src/lib/map/LeafletMap.ts
@@ -263,12 +263,12 @@ export class LeafletMap {
 			{ color: 'green', weight: 5 }
 		);
 
-		// Add layers to map
-		if (shortestLayer) {
-			this.routeLayer = shortestLayer.addTo(this.map);
-		}
+		// Add layers to map (add others first so shortest renders on top)
 		if (othersLayer) {
 			this.otherRoutesLayer = othersLayer.addTo(this.map);
+		}
+		if (shortestLayer) {
+			this.routeLayer = shortestLayer.addTo(this.map);
 		}
 
 		// Fit bounds


### PR DESCRIPTION
Adjust routing weight multipliers to strongly discourage routes where bikes are not allowed, strongly discourage mountain bike trails, and discourage stairs (to a lesser extent than the others). Rename the label on the best route to 'Best Route' from somewhat misleading 'Shortest Route' (since it is not necessarily the shortest by distance, only by cumulative edge weight). Show the blue best route line on top of the alternative green routes, which is important when there is overlap. Move time/distance displays from top right to bottom left of the map to fix overlap with the 'Hide' button for the sidebar.

Close #94
Close #83
Close #89 
Close #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route recommendations now account for different surface types (asphalt, gravel, dirt) when calculating optimal paths
  * Mountain bike trail designations are now considered in route scoring

* **Improvements**
  * Renamed "Shortest Route" to "Best Route" for improved clarity
  * Repositioned distance and time information to the bottom-left corner of the map for better visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->