### PR TITLE
feat(routing): move review multipliers to time of routing and prioritize user's own reviews

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -59,7 +59,7 @@ func main() {
 	waySvc := service.NewWayService(wayRepo)
 	reviewSvc := service.NewReviewService(reviewRepo)
 
-	netw, err := network.BuildNetwork(*nodeSvc, *waySvc, *reviewSvc)
+	netw, err := network.BuildNetwork(*nodeSvc, *waySvc)
 	if err != nil {
 		log.Fatalf("Error building network: %v", err)
 	}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/ellismcdougald/edmonton-bike-map/internal/domain/network"
+	"github.com/ellismcdougald/edmonton-bike-map/internal/domain/routing"
 	"github.com/ellismcdougald/edmonton-bike-map/internal/handler"
 	"github.com/ellismcdougald/edmonton-bike-map/internal/repository/sqlrepo"
 	internalserver "github.com/ellismcdougald/edmonton-bike-map/internal/server"
@@ -63,7 +64,13 @@ func main() {
 		log.Fatalf("Error building network: %v", err)
 	}
 
-	routeSvc := service.NewRouteService(netw)
+	allReviews, err := reviewSvc.GetAllReviews()
+	if err != nil {
+		log.Fatalf("Error fetching all reviews: %v", err)
+	}
+	mp := routing.NewMultiplierProvider(allReviews)
+
+	routeSvc := service.NewRouteService(netw, mp)
 
 	jwtSecret := []byte(os.Getenv("JWT_SECRET"))
 	tp := token.NewJWTProvider(jwtSecret)

--- a/backend/internal/domain/network/graph.go
+++ b/backend/internal/domain/network/graph.go
@@ -7,15 +7,11 @@ import (
 )
 
 // buildGraph constructs a Network graph from nodes, ways, and reviews.
-func buildGraph(nodes map[int64]models.Node, ways []models.Way, reviews map[int64][]models.Review) (*models.Network, error) {
+func buildGraph(nodes map[int64]models.Node, ways []models.Way) (*models.Network, error) {
 	edgesByNode := make(map[int64][]models.Edge, len(nodes))
 
 	for _, way := range ways {
 		tagsMultiplier := computeTagsMultiplier(way.Tags)
-		reviewMultiplier := 1.0
-		if wayReviews, ok := reviews[way.ID]; ok {
-			reviewMultiplier = computeReviewMultiplier(wayReviews)
-		}
 
 		for i := 0; i < len(way.NodeIDs)-1; i++ {
 			fromID := way.NodeIDs[i]
@@ -29,7 +25,7 @@ func buildGraph(nodes map[int64]models.Node, ways []models.Way, reviews map[int6
 			}
 
 			dist := haversineDistance(fromNode.Latitude, fromNode.Longitude, toNode.Latitude, toNode.Longitude)
-			weight := dist * tagsMultiplier * reviewMultiplier
+			weight := dist * tagsMultiplier
 
 			edgesByNode[fromID] = append(edgesByNode[fromID], models.Edge{
 				WayID:  way.ID,

--- a/backend/internal/domain/network/graph.go
+++ b/backend/internal/domain/network/graph.go
@@ -32,6 +32,7 @@ func buildGraph(nodes map[int64]models.Node, ways []models.Way, reviews map[int6
 			weight := dist * tagsMultiplier * reviewMultiplier
 
 			edgesByNode[fromID] = append(edgesByNode[fromID], models.Edge{
+				WayID:  way.ID,
 				To:     toID,
 				Weight: weight,
 			})

--- a/backend/internal/domain/network/graph.go
+++ b/backend/internal/domain/network/graph.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
 )
 
-// buildGraph constructs a Network graph from nodes, ways, and reviews.
+// buildGraph constructs a Network graph from nodes, ways.
 func buildGraph(nodes map[int64]models.Node, ways []models.Way) (*models.Network, error) {
 	edgesByNode := make(map[int64][]models.Edge, len(nodes))
 

--- a/backend/internal/domain/network/graph_test.go
+++ b/backend/internal/domain/network/graph_test.go
@@ -15,9 +15,8 @@ func TestBuildGraph_BasicEdgesAndOnewayAndMissingNodes(t *testing.T) {
 
 	// basic way (no tags)
 	ways := []models.Way{{ID: 11, Tags: map[string]string{}, NodeIDs: []int64{1, 2}}}
-	reviews := map[int64][]models.Review{}
 
-	net, err := buildGraph(nodes, ways, reviews)
+	net, err := buildGraph(nodes, ways)
 	require.NoError(t, err)
 
 	// edges from 1 -> 2 and 2 -> 1 (not oneway)
@@ -31,14 +30,14 @@ func TestBuildGraph_BasicEdgesAndOnewayAndMissingNodes(t *testing.T) {
 
 	// oneway should prevent reverse edge
 	ways2 := []models.Way{{ID: 12, Tags: map[string]string{"one_way": "yes"}, NodeIDs: []int64{1, 2}}}
-	net2, err := buildGraph(nodes, ways2, reviews)
+	net2, err := buildGraph(nodes, ways2)
 	require.NoError(t, err)
 	require.Len(t, net2.Edges[1], 1)
 	require.Len(t, net2.Edges[2], 0)
 
 	// missing nodes are skipped
 	ways3 := []models.Way{{ID: 13, Tags: map[string]string{}, NodeIDs: []int64{1, 3}}}
-	net3, err := buildGraph(nodes, ways3, reviews)
+	net3, err := buildGraph(nodes, ways3)
 	require.NoError(t, err)
 	// no edges should be added because 3 doesn't exist
 	require.Empty(t, net3.Edges[1])
@@ -51,17 +50,13 @@ func TestBuildGraph_RespectsReviewMultiplier(t *testing.T) {
 	}
 
 	ways := []models.Way{{ID: 21, Tags: map[string]string{}, NodeIDs: []int64{1, 2}}}
-	// one review with rating 5 -> review multiplier ~0.97
-	reviews := map[int64][]models.Review{
-		21: {{WayIDs: []int64{21}, Rating: 5}},
-	}
 
-	net, err := buildGraph(nodes, ways, reviews)
+	net, err := buildGraph(nodes, ways)
 	require.NoError(t, err)
 
 	require.Len(t, net.Edges[1], 1)
 	w := net.Edges[1][0].Weight
 	expectedDist := haversineDistance(nodes[1].Latitude, nodes[1].Longitude, nodes[2].Latitude, nodes[2].Longitude)
-	expected := expectedDist * computeTagsMultiplier(map[string]string{}) * computeReviewMultiplier(reviews[21])
+	expected := expectedDist * computeTagsMultiplier(map[string]string{})
 	require.InDelta(t, expected, w, 1e-6)
 }

--- a/backend/internal/domain/network/multipliers.go
+++ b/backend/internal/domain/network/multipliers.go
@@ -1,11 +1,5 @@
 package network
 
-import (
-	"math"
-
-	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
-)
-
 const (
 	tagBicycle      = "bicycle"
 	tagBike         = "bike"
@@ -84,30 +78,4 @@ func computeBikeFriendlyMultiplier(tags map[string]string) float64 {
 		bikeFriendlyMultiplier *= 5
 	}
 	return bikeFriendlyMultiplier
-}
-
-func computeReviewMultiplier(reviews []models.Review) float64 {
-	if len(reviews) == 0 {
-		return 1.0
-	}
-
-	total := 0
-	for _, review := range reviews {
-		rating := review.Rating
-		if rating < 1 {
-			rating = 1
-		}
-		if rating > 10 {
-			rating = 10
-		}
-		total += rating
-	}
-	average := float64(total) / float64(len(reviews))
-	score := (average - 1.0) / 9.0
-	multiplier := 1.3 - 0.75*score
-
-	// Consider number of reviews in strength of multiplier
-	confidence := math.Min(1.0, float64(len(reviews))/10.0)
-
-	return 1.0 + (multiplier-1.0)*confidence
 }

--- a/backend/internal/domain/network/multipliers.go
+++ b/backend/internal/domain/network/multipliers.go
@@ -93,11 +93,18 @@ func computeReviewMultiplier(reviews []models.Review) float64 {
 
 	total := 0
 	for _, review := range reviews {
-		total += review.Rating
+		rating := review.Rating
+		if rating < 1 {
+			rating = 1
+		}
+		if rating > 10 {
+			rating = 10
+		}
+		total += rating
 	}
 	average := float64(total) / float64(len(reviews))
-
-	multiplier := 1.2 - 0.1*average
+	score := (average - 1.0) / 9.0
+	multiplier := 1.3 - 0.75*score
 
 	// Consider number of reviews in strength of multiplier
 	confidence := math.Min(1.0, float64(len(reviews))/10.0)

--- a/backend/internal/domain/network/multipliers_test.go
+++ b/backend/internal/domain/network/multipliers_test.go
@@ -45,17 +45,18 @@ func TestComputeReviewMultiplier_Behaviour(t *testing.T) {
 	r := computeReviewMultiplier([]models.Review{})
 	require.InDelta(t, 1.0, r, 1e-9)
 
-	// one review rating 5 -> average 5 -> multiplier = 1.2 - 0.1*5 = 0.7
-	// confidence = 0.1 -> final = 1 + (0.7-1)*0.1 = 0.97
+	// one review rating 5 -> average 5 -> score = 4/9
+	// multiplier = 1.3 - 0.75*score ≈ 0.9666667
+	// confidence = 0.1 -> final ≈ 0.9966667
 	revs := []models.Review{{Rating: 5}}
 	r2 := computeReviewMultiplier(revs)
-	require.InDelta(t, 0.97, r2, 1e-9)
+	require.InDelta(t, 0.9966667, r2, 1e-7)
 
-	// ten reviews -> confidence 1 -> final equals multiplier for avg=5 (0.7)
+	// ten reviews -> confidence 1 -> final equals multiplier for avg=5 (≈0.9666667)
 	ten := make([]models.Review, 10)
 	for i := 0; i < 10; i++ {
 		ten[i] = models.Review{Rating: 5}
 	}
 	r3 := computeReviewMultiplier(ten)
-	require.InDelta(t, 0.7, r3, 1e-9)
+	require.InDelta(t, 0.9666667, r3, 1e-7)
 }

--- a/backend/internal/domain/network/multipliers_test.go
+++ b/backend/internal/domain/network/multipliers_test.go
@@ -3,7 +3,6 @@ package network
 import (
 	"testing"
 
-	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,25 +37,4 @@ func TestComputeBikeFriendlyMultiplier_And_TagsMultiplier(t *testing.T) {
 	mult := computeTagsMultiplier(tags4)
 	// bikeFriendly 0.9, highway would be 1.5 but should be forced to 1 -> result 0.9
 	require.InDelta(t, 0.9, mult, 1e-9)
-}
-
-func TestComputeReviewMultiplier_Behaviour(t *testing.T) {
-	// no reviews -> 1
-	r := computeReviewMultiplier([]models.Review{})
-	require.InDelta(t, 1.0, r, 1e-9)
-
-	// one review rating 5 -> average 5 -> score = 4/9
-	// multiplier = 1.3 - 0.75*score ≈ 0.9666667
-	// confidence = 0.1 -> final ≈ 0.9966667
-	revs := []models.Review{{Rating: 5}}
-	r2 := computeReviewMultiplier(revs)
-	require.InDelta(t, 0.9966667, r2, 1e-7)
-
-	// ten reviews -> confidence 1 -> final equals multiplier for avg=5 (≈0.9666667)
-	ten := make([]models.Review, 10)
-	for i := 0; i < 10; i++ {
-		ten[i] = models.Review{Rating: 5}
-	}
-	r3 := computeReviewMultiplier(ten)
-	require.InDelta(t, 0.9666667, r3, 1e-7)
 }

--- a/backend/internal/domain/network/network.go
+++ b/backend/internal/domain/network/network.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ellismcdougald/edmonton-bike-map/internal/service"
 )
 
-func BuildNetwork(nodeService service.NodeService, wayService service.WayService, reviewService service.ReviewService) (*models.Network, error) {
+func BuildNetwork(nodeService service.NodeService, wayService service.WayService) (*models.Network, error) {
 	allNodes, err := nodeService.GetAllNodes()
 	if err != nil {
 		return nil, err
@@ -15,11 +15,5 @@ func BuildNetwork(nodeService service.NodeService, wayService service.WayService
 	if err != nil {
 		return nil, err
 	}
-
-	allReviews, err := reviewService.GetAllReviews()
-	if err != nil {
-		return nil, err
-	}
-
-	return buildGraph(allNodes, allWays, allReviews)
+	return buildGraph(allNodes, allWays)
 }

--- a/backend/internal/domain/network/network_test.go
+++ b/backend/internal/domain/network/network_test.go
@@ -49,30 +49,17 @@ func (m *mockWayRepo) GetWaysByNodeIDs(nodeIDs []int64) ([]models.Way, error) {
 	return nil, nil
 }
 
-type mockReviewRepo struct {
-	revs map[int64][]models.Review
-	err  error
-}
-
-func (m *mockReviewRepo) CreateReview(review *models.Review) error                   { return nil }
-func (m *mockReviewRepo) GetReviews(wayID int64) ([]models.Review, error)            { return m.revs[wayID], nil }
-func (m *mockReviewRepo) GetAllReviews() (map[int64][]models.Review, error)          { return m.revs, m.err }
-func (m *mockReviewRepo) InsertBatches(reviews []models.Review, batchSize int) error { return nil }
-func (m *mockReviewRepo) DeleteUserReviewForWay(userID int64, wayID int64) error     { return nil }
-
 func TestBuildNetwork_SuccessAndEmpty(t *testing.T) {
 	nodes := map[int64]models.Node{
 		1: {ID: 1, Latitude: 50.0, Longitude: -113.0},
 		2: {ID: 2, Latitude: 50.1, Longitude: -113.1},
 	}
 	ways := []models.Way{{ID: 11, Tags: map[string]string{}, NodeIDs: []int64{1, 2}}}
-	reviews := map[int64][]models.Review{}
 
 	nodeSvc := service.NodeService{NodeRepository: &mockNodeRepo{nodes: nodes}}
 	waySvc := service.WayService{WayRepository: &mockWayRepo{ways: ways}}
-	reviewSvc := service.ReviewService{ReviewRepository: &mockReviewRepo{revs: reviews}}
 
-	net, err := BuildNetwork(nodeSvc, waySvc, reviewSvc)
+	net, err := BuildNetwork(nodeSvc, waySvc)
 	require.NoError(t, err)
 	require.Equal(t, nodes, net.Nodes)
 	require.NotNil(t, net.Edges)
@@ -80,9 +67,8 @@ func TestBuildNetwork_SuccessAndEmpty(t *testing.T) {
 	// empty datasets -> no panic and empty network
 	emptyNodeSvc := service.NodeService{NodeRepository: &mockNodeRepo{nodes: map[int64]models.Node{}}}
 	emptyWaySvc := service.WayService{WayRepository: &mockWayRepo{ways: []models.Way{}}}
-	emptyReviewSvc := service.ReviewService{ReviewRepository: &mockReviewRepo{revs: map[int64][]models.Review{}}}
 
-	net2, err := BuildNetwork(emptyNodeSvc, emptyWaySvc, emptyReviewSvc)
+	net2, err := BuildNetwork(emptyNodeSvc, emptyWaySvc)
 	require.NoError(t, err)
 	require.NotNil(t, net2)
 	require.Empty(t, net2.Nodes)
@@ -92,25 +78,21 @@ func TestBuildNetwork_PropagatesErrors(t *testing.T) {
 	want := errors.New("node failure")
 	nodeSvc := service.NodeService{NodeRepository: &mockNodeRepo{nodes: nil, err: want}}
 	waySvc := service.WayService{WayRepository: &mockWayRepo{ways: nil}}
-	reviewSvc := service.ReviewService{ReviewRepository: &mockReviewRepo{revs: nil}}
 
-	net, err := BuildNetwork(nodeSvc, waySvc, reviewSvc)
+	net, err := BuildNetwork(nodeSvc, waySvc)
 	require.Nil(t, net)
 	require.ErrorIs(t, err, want)
 
 	want2 := errors.New("way failure")
 	nodeSvc2 := service.NodeService{NodeRepository: &mockNodeRepo{nodes: map[int64]models.Node{}}}
 	waySvc2 := service.WayService{WayRepository: &mockWayRepo{ways: nil, err: want2}}
-	reviewSvc2 := service.ReviewService{ReviewRepository: &mockReviewRepo{revs: nil}}
-	net2, err2 := BuildNetwork(nodeSvc2, waySvc2, reviewSvc2)
+	net2, err2 := BuildNetwork(nodeSvc2, waySvc2)
 	require.Nil(t, net2)
 	require.ErrorIs(t, err2, want2)
 
-	want3 := errors.New("review failure")
 	nodeSvc3 := service.NodeService{NodeRepository: &mockNodeRepo{nodes: map[int64]models.Node{}}}
 	waySvc3 := service.WayService{WayRepository: &mockWayRepo{ways: []models.Way{}}}
-	reviewSvc3 := service.ReviewService{ReviewRepository: &mockReviewRepo{revs: nil, err: want3}}
-	net3, err3 := BuildNetwork(nodeSvc3, waySvc3, reviewSvc3)
-	require.Nil(t, net3)
-	require.ErrorIs(t, err3, want3)
+	net3, err3 := BuildNetwork(nodeSvc3, waySvc3)
+	require.NoError(t, err3)
+	require.NotNil(t, net3)
 }

--- a/backend/internal/domain/routing/findroute_multiplier_test.go
+++ b/backend/internal/domain/routing/findroute_multiplier_test.go
@@ -1,0 +1,79 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+// build a simple graph with two alternative paths between 1 and 4.
+// Path A: 1->2->4 (wayID 10)
+// Path B: 1->3->4 (wayID 20)
+func makeTestNetwork() *models.Network {
+	nodes := map[int64]models.Node{
+		1: {ID: 1},
+		2: {ID: 2},
+		3: {ID: 3},
+		4: {ID: 4},
+	}
+
+	edges := map[int64][]models.Edge{
+		1: {
+			{WayID: 10, To: 2, Weight: 1.0},
+			{WayID: 20, To: 3, Weight: 1.25},
+		},
+		2: {
+			{WayID: 10, To: 4, Weight: 1.0},
+		},
+		3: {
+			{WayID: 20, To: 4, Weight: 1.25},
+		},
+	}
+
+	return &models.Network{Nodes: nodes, Edges: edges}
+}
+
+func makeReviewsForRating(rating int, count int) []models.Review {
+	out := make([]models.Review, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, models.Review{UserID: int64(i + 1), Rating: rating})
+	}
+	return out
+}
+
+func TestFindRoute_RespectsReviewMultipliers(t *testing.T) {
+	g := makeTestNetwork()
+
+	// Path A has many bad reviews -> multiplier > 1
+	// Path B has many good reviews -> multiplier < 1
+	reviews := map[int64][]models.Review{
+		10: makeReviewsForRating(1, 10),
+		20: makeReviewsForRating(10, 10),
+	}
+	mp := NewMultiplierProvider(reviews)
+
+	_, path := findRoute(g, 1, 4, nil, mp)
+	// expect path B chosen: 1 -> 3 -> 4
+	require.Equal(t, []int64{1, 3, 4}, path)
+}
+
+func TestFindRoute_UserOverridePrefersTheirReview(t *testing.T) {
+	g := makeTestNetwork()
+
+	// Global reviews favour path B, but user has left a high rating on path A.
+	reviews := map[int64][]models.Review{
+		10: makeReviewsForRating(1, 10),
+		20: makeReviewsForRating(10, 10),
+	}
+	// insert a user review (user id 999) with high rating for way 10
+	userID := int64(999)
+	userReview := models.Review{UserID: userID, Rating: 9}
+	reviews[10] = append(reviews[10], userReview)
+
+	mp := NewMultiplierProvider(reviews)
+
+	_, path := findRoute(g, 1, 4, &userID, mp)
+	// user-specific rating should favour path A: 1 -> 2 -> 4
+	require.Equal(t, []int64{1, 2, 4}, path)
+}

--- a/backend/internal/domain/routing/multi_router.go
+++ b/backend/internal/domain/routing/multi_router.go
@@ -18,7 +18,7 @@ type Route struct {
 //   - The first route is always the shortest path; subsequent routes aim for diversity.
 //   - Suppresses duplicate paths and returns routes ordered by distance/discovery.
 //   - Returns an empty slice if k <= 0 and may stop early if no more paths exist.
-func FindMultipleRoutes(network *models.Network, start, end int64, k int) []Route {
+func FindMultipleRoutes(network *models.Network, start, end int64, userID *int64, mp *MultiplierProvider, k int) []Route {
 	if k <= 0 {
 		return []Route{}
 	}
@@ -52,7 +52,7 @@ func FindMultipleRoutes(network *models.Network, start, end int64, k int) []Rout
 		}
 
 		// Find shortest path with penalized weights
-		_, prev, found := dijkstra(network, start, end, edgeWeights)
+		_, prev, found := dijkstra(network, start, end, userID, edgeWeights, mp)
 		if !found {
 			// No more paths available
 			break
@@ -80,10 +80,10 @@ func FindMultipleRoutes(network *models.Network, start, end int64, k int) []Rout
 
 // FindMultipleRoutesFromCoordinates finds up to k diverse routes between the network nodes nearest the given start and end latitude/longitude coordinates.
 // It maps each coordinate to the nearest node in the network and returns up to k distinct routes connecting those nodes.
-func FindMultipleRoutesFromCoordinates(network *models.Network, startLatitude, startLongitude, endLatitude, endLongitude float64, k int) []Route {
+func FindMultipleRoutesFromCoordinates(network *models.Network, startLatitude, startLongitude, endLatitude, endLongitude float64, userID *int64, mp *MultiplierProvider, k int) []Route {
 	startNodeID := nearestNode(startLatitude, startLongitude, network.Nodes)
 	endNodeID := nearestNode(endLatitude, endLongitude, network.Nodes)
-	return FindMultipleRoutes(network, startNodeID, endNodeID, k)
+	return FindMultipleRoutes(network, startNodeID, endNodeID, userID, mp, k)
 }
 
 // pathsEqual reports whether two paths contain the same sequence of node IDs.

--- a/backend/internal/domain/routing/multi_router_test.go
+++ b/backend/internal/domain/routing/multi_router_test.go
@@ -22,7 +22,7 @@ func TestFindMultipleRoutes_HappyPath(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 3, 1)
+	routes := FindMultipleRoutes(g, 1, 3, nil, nil, 1)
 	require.Equal(t, 1, len(routes))
 	require.Equal(t, []int64{1, 2, 3}, routes[0].Path)
 }
@@ -46,7 +46,7 @@ func TestFindMultipleRoutes_MultipleAlternatives(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 4, 2)
+	routes := FindMultipleRoutes(g, 1, 4, nil, nil, 2)
 	require.Equal(t, 2, len(routes))
 
 	// First route should be cheapest
@@ -71,7 +71,7 @@ func TestFindMultipleRoutes_K_Greater_Than_Paths(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 3, 5)
+	routes := FindMultipleRoutes(g, 1, 3, nil, nil, 5)
 	// Only 1 path exists in this linear graph
 	require.Equal(t, 1, len(routes))
 	require.Equal(t, []int64{1, 2, 3}, routes[0].Path)
@@ -83,7 +83,7 @@ func TestFindMultipleRoutes_SameNode(t *testing.T) {
 	}
 	g := &models.Network{Nodes: nodes, Edges: map[int64][]models.Edge{}}
 
-	routes := FindMultipleRoutes(g, 1, 1, 1)
+	routes := FindMultipleRoutes(g, 1, 1, nil, nil, 1)
 	require.Equal(t, 1, len(routes))
 	require.Equal(t, []int64{1}, routes[0].Path)
 	require.Equal(t, 0.0, routes[0].Distance)
@@ -103,7 +103,7 @@ func TestFindMultipleRoutes_Unreachable(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 2, 1)
+	routes := FindMultipleRoutes(g, 1, 2, nil, nil, 1)
 	require.Equal(t, 0, len(routes))
 }
 
@@ -119,7 +119,7 @@ func TestFindMultipleRoutes_ZeroK(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 2, 0)
+	routes := FindMultipleRoutes(g, 1, 2, nil, nil, 0)
 	require.Equal(t, 0, len(routes))
 }
 
@@ -138,7 +138,7 @@ func TestFindMultipleRoutesFromCoordinates(t *testing.T) {
 	}
 
 	// Both coordinates map to node 1
-	routes := FindMultipleRoutesFromCoordinates(g, 0, 0, 1, 1, 1)
+	routes := FindMultipleRoutesFromCoordinates(g, 0, 0, 1, 1, nil, nil, 1)
 	require.Equal(t, 1, len(routes))
 	require.Equal(t, []int64{1, 2, 3}, routes[0].Path)
 }
@@ -165,7 +165,7 @@ func TestFindMultipleRoutes_ComplexGraph(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 5, 3)
+	routes := FindMultipleRoutes(g, 1, 5, nil, nil, 3)
 	// Should find at least 2 distinct paths
 	require.True(t, len(routes) >= 1)
 
@@ -192,7 +192,7 @@ func TestFindMultipleRoutes_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	routes := FindMultipleRoutes(g, 1, 4, 10)
+	routes := FindMultipleRoutes(g, 1, 4, nil, nil, 10)
 
 	// Check for duplicates
 	for i := 0; i < len(routes); i++ {

--- a/backend/internal/domain/routing/multiplier_provider.go
+++ b/backend/internal/domain/routing/multiplier_provider.go
@@ -14,5 +14,10 @@ func NewMultiplierProvider(reviews map[int64][]models.Review) *MultiplierProvide
 
 // MultiplierFor returns the weight multiplier for a given way and user.
 func (mp *MultiplierProvider) MultiplierFor(wayID int64, userID *int64) float64 {
-	return 1.0
+	reviewMultiplier := 1.0
+	if reviews, exists := mp.reviews[wayID]; exists {
+		reviewMultiplier = computeReviewMultiplier(reviews, userID)
+	}
+
+	return reviewMultiplier
 }

--- a/backend/internal/domain/routing/multiplier_provider.go
+++ b/backend/internal/domain/routing/multiplier_provider.go
@@ -1,0 +1,18 @@
+package routing
+
+import "github.com/ellismcdougald/edmonton-bike-map/internal/models"
+
+// MultiplierProvider provides weight multipliers for ways based on reviews.
+type MultiplierProvider struct {
+	reviews map[int64][]models.Review // Map of way IDs to their reviews
+}
+
+// NewMultiplierProvider creates a new MultiplierProvider instance.
+func NewMultiplierProvider(reviews map[int64][]models.Review) *MultiplierProvider {
+	return &MultiplierProvider{reviews: reviews}
+}
+
+// MultiplierFor returns the weight multiplier for a given way and user.
+func (mp *MultiplierProvider) MultiplierFor(wayID int64, userID *int64) float64 {
+	return 1.0
+}

--- a/backend/internal/domain/routing/multipliers.go
+++ b/backend/internal/domain/routing/multipliers.go
@@ -1,0 +1,54 @@
+package routing
+
+import (
+	"math"
+
+	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
+)
+
+func clampRating(r int) int {
+	if r < 1 {
+		return 1
+	}
+	if r > 10 {
+		return 10
+	}
+	return r
+}
+
+func computeReviewMultiplier(reviews []models.Review, userID *int64) float64 {
+	if len(reviews) == 0 {
+		return 1.0
+	}
+
+	total := 0
+	count := 0
+	foundUser := false
+
+	for _, review := range reviews {
+		if userID != nil && review.UserID == *userID {
+			foundUser = true
+			r := clampRating(review.Rating)
+			total = r
+			count = 1
+			break
+		}
+		r := clampRating(review.Rating)
+		total += r
+		count++
+	}
+
+	average := float64(total) / float64(count)
+	score := (average - 1.0) / 9.0
+	multiplier := 1.3 - 0.75*score
+
+	// Consider number of reviews in strength of multiplier
+	var confidence float64
+	if foundUser {
+		confidence = 1.0
+	} else {
+		confidence = math.Min(1.0, float64(count)/10.0)
+	}
+
+	return 1.0 + (multiplier-1.0)*confidence
+}

--- a/backend/internal/domain/routing/multipliers_test.go
+++ b/backend/internal/domain/routing/multipliers_test.go
@@ -1,0 +1,58 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeReviewMultiplier_NoReviews(t *testing.T) {
+	got := computeReviewMultiplier([]models.Review{}, nil)
+	require.Equal(t, 1.0, got)
+}
+
+func TestComputeReviewMultiplier_SingleReview_NoUser(t *testing.T) {
+	reviews := []models.Review{{UserID: 2, Rating: 10}}
+	got := computeReviewMultiplier(reviews, nil)
+	// expected: 0.955 (see formula in code)
+	require.InDelta(t, 0.955, got, 1e-6)
+}
+
+func TestComputeReviewMultiplier_UserReviewOverrides(t *testing.T) {
+	uid := int64(5)
+	reviews := []models.Review{{UserID: 3, Rating: 2}, {UserID: 5, Rating: 8}, {UserID: 6, Rating: 9}}
+	got := computeReviewMultiplier(reviews, &uid)
+	// when user's review exists, multiplier uses that rating directly -> ~0.7166666667
+	require.InDelta(t, 0.7166666666666667, got, 1e-9)
+}
+
+func TestComputeReviewMultiplier_MultipleReviews_ConfidenceScaling(t *testing.T) {
+	reviews := []models.Review{{Rating: 5}, {Rating: 7}, {Rating: 9}}
+	got := computeReviewMultiplier(reviews, nil)
+	// average 7 -> multiplier 0.8, confidence 0.3 -> result 0.94
+	require.InDelta(t, 0.94, got, 1e-9)
+}
+
+func TestComputeReviewMultiplier_ClampsRatings(t *testing.T) {
+	// rating below 1 is clamped to 1; above 10 clamped to 10
+	reviews := []models.Review{{Rating: 0}, {Rating: 11}}
+	got := computeReviewMultiplier(reviews, nil)
+	// after clamping both -> [1,10] average 5.5 -> score=(5.5-1)/9=0.5 -> multiplier=1.3-0.75*0.5=0.925
+	// confidence = min(1,2/10)=0.2 -> result = 1 + (0.925-1)*0.2 = 1 - 0.015 = 0.985
+	require.InDelta(t, 0.985, got, 1e-9)
+}
+
+func TestMultiplierProvider_MultiplierFor(t *testing.T) {
+	reviewsMap := map[int64][]models.Review{
+		42: {{Rating: 9}},
+	}
+	mp := NewMultiplierProvider(reviewsMap)
+
+	// non-existent way -> 1.0
+	require.Equal(t, 1.0, mp.MultiplierFor(1, nil))
+
+	// existing way -> computed multiplier
+	got := mp.MultiplierFor(42, nil)
+	require.InDelta(t, 0.9633333333333334, got, 1e-9)
+}

--- a/backend/internal/domain/routing/router.go
+++ b/backend/internal/domain/routing/router.go
@@ -10,8 +10,8 @@ import (
 // findRoute finds the lowest-cost route between two nodes in the network.
 // It returns the total estimated distance along the route and the sequence of node IDs from start to end.
 // If no route exists between the nodes, it returns -1 and nil.
-func findRoute(network *models.Network, start, end int64) (dist float64, path []int64) {
-	_, prev, found := dijkstra(network, start, end, nil)
+func findRoute(network *models.Network, start, end int64, userId *int64, mp *MultiplierProvider) (dist float64, path []int64) {
+	_, prev, found := dijkstra(network, start, end, userId, nil, mp)
 	if !found {
 		return -1, nil
 	}
@@ -32,7 +32,7 @@ func findRoute(network *models.Network, start, end int64) (dist float64, path []
 // - dist: map of shortest distances from `start` to each node (math.Inf(1) for unreachable nodes)
 // - prev: predecessor map for reconstructing a shortest path from `start`
 // - found: true if `goal` was reached (finite distance), false otherwise
-func dijkstra(g *models.Network, start, goal int64, edgeWeights map[[2]int64]float64) (dist map[int64]float64, prev map[int64]int64, found bool) {
+func dijkstra(g *models.Network, start, goal int64, userId *int64, edgeWeights map[[2]int64]float64, mp *MultiplierProvider) (dist map[int64]float64, prev map[int64]int64, found bool) {
 	dist = make(map[int64]float64)
 	prev = make(map[int64]int64)
 
@@ -72,6 +72,9 @@ func dijkstra(g *models.Network, start, goal int64, edgeWeights map[[2]int64]flo
 				if w, ok := edgeWeights[[2]int64{u, v}]; ok {
 					weight = w
 				}
+			}
+			if mp != nil {
+				weight *= mp.MultiplierFor(edge.WayID, userId)
 			}
 
 			alt := dist[u] + weight

--- a/backend/internal/domain/routing/router_test.go
+++ b/backend/internal/domain/routing/router_test.go
@@ -30,7 +30,7 @@ func TestDijkstraSimple(t *testing.T) {
 		},
 	}
 
-	dist, prev, found := dijkstra(g, 1, 3, nil)
+	dist, prev, found := dijkstra(g, 1, 3, nil, nil, nil)
 	require.True(t, found)
 	require.InDelta(t, 4.0, dist[3], 1e-9)
 	require.Equal(t, int64(2), prev[3])
@@ -49,7 +49,7 @@ func TestDijkstraUnreachable(t *testing.T) {
 		},
 	}
 
-	dist, _, found := dijkstra(g, 1, 3, nil)
+	dist, _, found := dijkstra(g, 1, 3, nil, nil, nil)
 	require.False(t, found)
 	require.True(t, math.IsInf(dist[3], 1))
 }
@@ -69,7 +69,7 @@ func TestFindRoute_EndToEnd(t *testing.T) {
 		},
 	}
 
-	d, path := findRoute(g, 1, 3)
+	d, path := findRoute(g, 1, 3, nil, nil)
 	require.Equal(t, []int64{1, 2, 3}, path)
 	// distance returned by findRoute is estimateDistance(path, nodes)
 	want := estimateDistance(path, nodes)
@@ -88,12 +88,12 @@ func TestFindRoute_UnreachableAndSameNode(t *testing.T) {
 	}
 
 	// unreachable
-	d, path := findRoute(g, 2, 1)
+	d, path := findRoute(g, 2, 1, nil, nil)
 	require.Equal(t, -1.0, d)
 	require.Nil(t, path)
 
 	// same node
-	d2, path2 := findRoute(g, 1, 1)
+	d2, path2 := findRoute(g, 1, 1, nil, nil)
 	require.Equal(t, 0.0, d2)
 	require.Equal(t, []int64{1}, path2)
 }
@@ -114,7 +114,7 @@ func TestDijkstra_EqualWeightPaths(t *testing.T) {
 		},
 	}
 
-	_, prev, found := dijkstra(g, 1, 4, nil)
+	_, prev, found := dijkstra(g, 1, 4, nil, nil, nil)
 	require.True(t, found)
 	// reconstructPath should return a valid shortest path of length 3
 	path := reconstructPath(prev, 4)
@@ -138,7 +138,7 @@ func TestDijkstra_WithCycle(t *testing.T) {
 		},
 	}
 
-	dist, _, found := dijkstra(g, 1, 3, nil)
+	dist, _, found := dijkstra(g, 1, 3, nil, nil, nil)
 	require.True(t, found)
 	require.InDelta(t, 2.0, dist[3], 1e-9)
 }
@@ -156,7 +156,7 @@ func TestDijkstra_SelfLoop(t *testing.T) {
 		},
 	}
 
-	dist, _, found := dijkstra(g, 1, 2, nil)
+	dist, _, found := dijkstra(g, 1, 2, nil, nil, nil)
 	require.True(t, found)
 	require.InDelta(t, 1.0, dist[2], 1e-9)
 }

--- a/backend/internal/domain/routing/routing.go
+++ b/backend/internal/domain/routing/routing.go
@@ -3,8 +3,8 @@ package routing
 import "github.com/ellismcdougald/edmonton-bike-map/internal/models"
 
 // FindRouteFromCoordinates returns the lowest-cost route between two latitude-longitude pairs.
-func FindRouteFromCoordinates(network *models.Network, startLatitude, startLongitude, endLatitude, endLongitude float64) (dist float64, path []int64) {
+func FindRouteFromCoordinates(network *models.Network, startLatitude, startLongitude, endLatitude, endLongitude float64, userID *int64, mp *MultiplierProvider) (dist float64, path []int64) {
 	startNodeID := nearestNode(startLatitude, startLongitude, network.Nodes)
 	endNodeID := nearestNode(endLatitude, endLongitude, network.Nodes)
-	return findRoute(network, startNodeID, endNodeID)
+	return findRoute(network, startNodeID, endNodeID, userID, mp)
 }

--- a/backend/internal/domain/routing/routing_test.go
+++ b/backend/internal/domain/routing/routing_test.go
@@ -21,7 +21,7 @@ func TestFindRouteFromCoordinates_HappyPath(t *testing.T) {
 		},
 	}
 
-	d, path := FindRouteFromCoordinates(g, 0, 0, 1, 1)
+	d, path := FindRouteFromCoordinates(g, 0, 0, 1, 1, nil, nil)
 	require.Equal(t, []int64{1, 2, 3}, path)
 	want := estimateDistance(path, nodes)
 	require.InDelta(t, want, d, 1e-9)
@@ -33,7 +33,7 @@ func TestFindRouteFromCoordinates_SameNode(t *testing.T) {
 	}
 	g := &models.Network{Nodes: nodes, Edges: map[int64][]models.Edge{}}
 
-	d, path := FindRouteFromCoordinates(g, 53.5461, -113.4938, 53.5461, -113.4938)
+	d, path := FindRouteFromCoordinates(g, 53.5461, -113.4938, 53.5461, -113.4938, nil, nil)
 	require.Equal(t, []int64{1}, path)
 	require.Equal(t, 0.0, d)
 }
@@ -48,7 +48,7 @@ func TestFindRouteFromCoordinates_Unreachable(t *testing.T) {
 		2: {},
 	}}
 
-	d, path := FindRouteFromCoordinates(g, 0, 0, 10, 10)
+	d, path := FindRouteFromCoordinates(g, 0, 0, 10, 10, nil, nil)
 	require.Equal(t, -1.0, d)
 	require.Nil(t, path)
 }

--- a/backend/internal/handler/route_handler.go
+++ b/backend/internal/handler/route_handler.go
@@ -58,7 +58,13 @@ func (h *RouteHandler) HandleGetRoute() http.HandlerFunc {
 			return
 		}
 
-		dist, nodes, err := h.RouteService.FindRoute(startLatitude, startLongitude, endLatitude, endLongitude)
+		var userIDPtr *int64
+		userID, ok := middleware.UserIDFromContext(request.Context())
+		if ok {
+			userIDPtr = &userID
+		}
+
+		dist, nodes, err := h.RouteService.FindRoute(startLatitude, startLongitude, endLatitude, endLongitude, userIDPtr)
 		if err != nil {
 			log.Printf("error finding route: %v", err)
 			http.Error(writer, "internal server error", http.StatusInternalServerError)
@@ -80,7 +86,6 @@ func (h *RouteHandler) HandleGetRoute() http.HandlerFunc {
 
 		// Get cycling speed: use user's preferred speed if authenticated, otherwise use default
 		cyclingSpeed := DefaultCyclingSpeed
-		userID, ok := middleware.UserIDFromContext(request.Context())
 		if ok {
 			userSpeed, err := h.UserService.GetCyclingSpeed(userID)
 			if err != nil {
@@ -159,7 +164,13 @@ func (h *RouteHandler) HandleGetRoutes() http.HandlerFunc {
 			k = parsedK
 		}
 
-		routes, err := h.RouteService.FindMultipleRoutes(startLatitude, startLongitude, endLatitude, endLongitude, k)
+		var userIDPtr *int64
+		userID, ok := middleware.UserIDFromContext(request.Context())
+		if ok {
+			userIDPtr = &userID
+		}
+
+		routes, err := h.RouteService.FindMultipleRoutes(startLatitude, startLongitude, endLatitude, endLongitude, userIDPtr, k)
 		if err != nil {
 			log.Printf("error finding routes: %v", err)
 			http.Error(writer, "internal server error", http.StatusInternalServerError)
@@ -173,7 +184,6 @@ func (h *RouteHandler) HandleGetRoutes() http.HandlerFunc {
 
 		// Get cycling speed: use user's preferred speed if authenticated, otherwise use default
 		cyclingSpeed := DefaultCyclingSpeed
-		userID, ok := middleware.UserIDFromContext(request.Context())
 		if ok {
 			userSpeed, err := h.UserService.GetCyclingSpeed(userID)
 			if err != nil {

--- a/backend/internal/handler/route_handler_multiplier_test.go
+++ b/backend/internal/handler/route_handler_multiplier_test.go
@@ -1,0 +1,123 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ellismcdougald/edmonton-bike-map/internal/domain/routing"
+	"github.com/ellismcdougald/edmonton-bike-map/internal/middleware"
+	"github.com/ellismcdougald/edmonton-bike-map/internal/models"
+	"github.com/ellismcdougald/edmonton-bike-map/internal/service"
+)
+
+// Build a small network similar to findroute tests but with lat/lon for coordinates
+func makeHandlerTestNetwork() *models.Network {
+	nodes := map[int64]models.Node{
+		1: {ID: 1, Latitude: 0, Longitude: 0},
+		2: {ID: 2, Latitude: 0, Longitude: 1},
+		3: {ID: 3, Latitude: 1, Longitude: 0},
+		4: {ID: 4, Latitude: 1, Longitude: 1},
+	}
+
+	// Two alternative paths from 1->4: via 2 (way 10) and via 3 (way 20)
+	edges := map[int64][]models.Edge{
+		1: {{WayID: 10, To: 2, Weight: 1.0}, {WayID: 20, To: 3, Weight: 1.5}},
+		2: {{WayID: 10, To: 4, Weight: 1.0}},
+		3: {{WayID: 20, To: 4, Weight: 1.0}},
+	}
+
+	return &models.Network{Nodes: nodes, Edges: edges}
+}
+
+func TestHandleGetRoute_UsesReviewMultipliers_Guest(t *testing.T) {
+	g := makeHandlerTestNetwork()
+
+	// reviews favour way 20 -> path 1->3->4 should be chosen
+	reviews := map[int64][]models.Review{
+		10: {{Rating: 1}, {Rating: 2}},
+		20: {{Rating: 10}, {Rating: 9}},
+	}
+	mp := routing.NewMultiplierProvider(reviews)
+
+	// provide a mock user service (not used for guest path selection)
+	repo := &mockUserRepo{user: &models.User{ID: 1, CyclingSpeed: 15}}
+	userSvc := service.NewUserService(repo)
+
+	rh := NewRouteHandler(service.NewRouteService(g, mp), userSvc)
+
+	req, _ := http.NewRequest("GET", "/route?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1", nil)
+	rr := httptest.NewRecorder()
+
+	handler := rh.HandleGetRoute()
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	geom := resp["geometry"].(map[string]any)
+	coords := geom["coordinates"].([]any)
+
+	// coordinates should reflect nodes 1 -> 3 -> 4
+	// check length and final coordinate
+	if len(coords) != 3 {
+		t.Fatalf("expected 3 coords, got %d", len(coords))
+	}
+	last := coords[2].([]any)
+	if last[0].(float64) != 1 || last[1].(float64) != 1 {
+		t.Fatalf("unexpected final coord: %v", last)
+	}
+}
+
+func TestHandleGetRoute_UsesReviewMultipliers_UserOverride(t *testing.T) {
+	g := makeHandlerTestNetwork()
+
+	reviews := map[int64][]models.Review{
+		10: {{Rating: 1}, {Rating: 2}},
+		20: {{Rating: 10}, {Rating: 9}},
+	}
+	// user 999 has left a high rating on way 10, so they should prefer path via 2
+	userID := int64(999)
+	reviews[10] = append(reviews[10], models.Review{UserID: userID, Rating: 9})
+
+	mp := routing.NewMultiplierProvider(reviews)
+	repo := &mockUserRepo{user: &models.User{ID: userID, CyclingSpeed: 15}}
+	userSvc := service.NewUserService(repo)
+	rh := NewRouteHandler(service.NewRouteService(g, mp), userSvc)
+
+	req, _ := http.NewRequest("GET", "/route?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1", nil)
+	// inject user id into context (simulates optional auth middleware)
+	req = req.WithContext(middleware.UserIDToContext(req.Context(), userID))
+	rr := httptest.NewRecorder()
+
+	handler := rh.HandleGetRoute()
+	handler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	geom := resp["geometry"].(map[string]any)
+	coords := geom["coordinates"].([]any)
+
+	// coordinates should reflect nodes 1 -> 2 -> 4
+	if len(coords) != 3 {
+		t.Fatalf("expected 3 coords, got %d", len(coords))
+	}
+	second := coords[1].([]any)
+	if second[0].(float64) != 1 || second[1].(float64) != 0 {
+		t.Fatalf("unexpected second coord: %v", second)
+	}
+}

--- a/backend/internal/handler/route_handler_test.go
+++ b/backend/internal/handler/route_handler_test.go
@@ -36,7 +36,7 @@ func TestHandleGetRoute_HappyPath(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/route?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -57,7 +57,7 @@ func TestHandleGetRoute_HappyPath(t *testing.T) {
 	require.True(t, ok)
 
 	// expected distance should match routing.FindRouteFromCoordinates on the same coords
-	expectedDist, _ := routing.FindRouteFromCoordinates(g, 0, 0, 1, 1)
+	expectedDist, _ := routing.FindRouteFromCoordinates(g, 0, 0, 1, 1, nil, nil)
 	require.InDelta(t, expectedDist, distVal, 1e-6)
 
 	geom, ok := resp["geometry"].(map[string]any)
@@ -81,7 +81,7 @@ func TestHandleGetRoute_Unreachable(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/route?startLatitude=0&startLongitude=0&endLatitude=10&endLongitude=10", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -100,7 +100,7 @@ func TestHandleGetRoute_BadRequest(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(&models.Network{Nodes: map[int64]models.Node{}, Edges: map[int64][]models.Edge{}}), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(&models.Network{Nodes: map[int64]models.Node{}, Edges: map[int64][]models.Edge{}}, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/route?startLatitude=notanumber&startLongitude=0&endLatitude=0&endLongitude=0", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -131,7 +131,7 @@ func TestHandleGetRoute_GuestAccess(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 20}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/route?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1", nil)
 	// NO Authorization header - guest access
 	rr := httptest.NewRecorder()
@@ -152,7 +152,7 @@ func TestHandleGetRoute_GuestAccess(t *testing.T) {
 	require.True(t, ok)
 
 	// expected distance should match routing.FindRouteFromCoordinates on the same coords
-	expectedDist, _ := routing.FindRouteFromCoordinates(g, 0, 0, 1, 1)
+	expectedDist, _ := routing.FindRouteFromCoordinates(g, 0, 0, 1, 1, nil, nil)
 	require.InDelta(t, expectedDist, distVal, 1e-6)
 
 	geom, ok := resp["geometry"].(map[string]any)
@@ -185,7 +185,7 @@ func TestHandleGetRoutes_HappyPath(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1&k=2", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -249,7 +249,7 @@ func TestHandleGetRoutes_DefaultK(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	// No k parameter - should default to 3
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -277,7 +277,7 @@ func TestHandleGetRoutes_InvalidK(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(&models.Network{Nodes: map[int64]models.Node{}, Edges: map[int64][]models.Edge{}}), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(&models.Network{Nodes: map[int64]models.Node{}, Edges: map[int64][]models.Edge{}}, nil), userSvc)
 
 	testCases := []struct {
 		name string
@@ -317,7 +317,7 @@ func TestHandleGetRoutes_Unreachable(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=0&startLongitude=0&endLatitude=10&endLongitude=10&k=3", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -336,7 +336,7 @@ func TestHandleGetRoutes_BadCoordinates(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(&models.Network{Nodes: map[int64]models.Node{}, Edges: map[int64][]models.Edge{}}), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(&models.Network{Nodes: map[int64]models.Node{}, Edges: map[int64][]models.Edge{}}, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=notanumber&startLongitude=0&endLatitude=0&endLongitude=0&k=3", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -368,7 +368,7 @@ func TestHandleGetRoutes_GuestAccess(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 20}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1&k=2", nil)
 	// NO Authorization header - guest access
 	rr := httptest.NewRecorder()
@@ -426,7 +426,7 @@ func TestHandleGetRoutes_MultipleRoutesIndexing(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1&k=3", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr := httptest.NewRecorder()
@@ -474,7 +474,7 @@ func TestHandleGetRoutes_FewerRoutesThanK(t *testing.T) {
 	repo := &mockUserRepo{user: &models.User{ID: 42, CyclingSpeed: 15}}
 	userSvc := service.NewUserService(repo)
 
-	rh := NewRouteHandler(service.NewRouteService(g), userSvc)
+	rh := NewRouteHandler(service.NewRouteService(g, nil), userSvc)
 	// Ask for 5 routes but only 1 exists
 	req, _ := http.NewRequest("GET", "/routes?startLatitude=0&startLongitude=0&endLatitude=1&endLongitude=1&k=5", nil)
 	req.Header.Set("Authorization", "Bearer "+token)

--- a/backend/internal/models/network.go
+++ b/backend/internal/models/network.go
@@ -2,6 +2,7 @@ package models
 
 // Edge represents a directed connection from one node to another with a weight
 type Edge struct {
+	WayID  int64   // ID of the way this edge belongs to
 	To     int64   // ID of the destination node
 	Weight float64 // computed weight (distance * multipliers)
 }

--- a/backend/internal/service/route_service.go
+++ b/backend/internal/service/route_service.go
@@ -8,20 +8,22 @@ import (
 )
 
 type RouteService struct {
-	network *models.Network
+	network            *models.Network
+	multiplierProvider *routing.MultiplierProvider
 }
 
 // NewRouteService creates a new instance of RouteService.
-func NewRouteService(network *models.Network) *RouteService {
+func NewRouteService(network *models.Network, mp *routing.MultiplierProvider) *RouteService {
 	return &RouteService{
-		network: network,
+		network:            network,
+		multiplierProvider: mp,
 	}
 }
 
 // FindRoute returns the distance (km) and the list of nodes representing the route between two coordinates.
 // If no route is found, distance will be -1 and nodes will be nil.
-func (s *RouteService) FindRoute(startLatitude, startLongitude, endLatitude, endLongitude float64) (float64, []models.Node, error) {
-	dist, ids := routing.FindRouteFromCoordinates(s.network, startLatitude, startLongitude, endLatitude, endLongitude)
+func (s *RouteService) FindRoute(startLatitude, startLongitude, endLatitude, endLongitude float64, userID *int64) (float64, []models.Node, error) {
+	dist, ids := routing.FindRouteFromCoordinates(s.network, startLatitude, startLongitude, endLatitude, endLongitude, userID, s.multiplierProvider)
 	if dist < 0 || ids == nil || len(ids) == 0 {
 		return dist, nil, nil
 	}
@@ -45,8 +47,8 @@ func (s *RouteService) FindRoute(startLatitude, startLongitude, endLatitude, end
 // FindMultipleRoutes returns the k shortest routes between two coordinates.
 // Each route includes the distance (km) and the list of nodes representing the route.
 // If no routes are found, an empty slice is returned.
-func (s *RouteService) FindMultipleRoutes(startLatitude, startLongitude, endLatitude, endLongitude float64, k int) ([]RouteResult, error) {
-	routes := routing.FindMultipleRoutesFromCoordinates(s.network, startLatitude, startLongitude, endLatitude, endLongitude, k)
+func (s *RouteService) FindMultipleRoutes(startLatitude, startLongitude, endLatitude, endLongitude float64, userID *int64, k int) ([]RouteResult, error) {
+	routes := routing.FindMultipleRoutesFromCoordinates(s.network, startLatitude, startLongitude, endLatitude, endLongitude, userID, s.multiplierProvider, k)
 	if len(routes) == 0 {
 		return []RouteResult{}, nil
 	}

--- a/backend/internal/service/route_service_test.go
+++ b/backend/internal/service/route_service_test.go
@@ -21,8 +21,8 @@ func TestFindRoute_HappyPath(t *testing.T) {
 		},
 	}
 
-	svc := NewRouteService(network)
-	dist, routeNodes, err := svc.FindRoute(0, 0, 1, 1)
+	svc := NewRouteService(network, nil)
+	dist, routeNodes, err := svc.FindRoute(0, 0, 1, 1, nil)
 
 	require.NoError(t, err)
 	require.Greater(t, dist, 0.0)
@@ -45,8 +45,8 @@ func TestFindRoute_NoRouteExists(t *testing.T) {
 		},
 	}
 
-	svc := NewRouteService(network)
-	dist, routeNodes, err := svc.FindRoute(0, 0, 10, 10)
+	svc := NewRouteService(network, nil)
+	dist, routeNodes, err := svc.FindRoute(0, 0, 10, 10, nil)
 
 	require.NoError(t, err)
 	require.Less(t, dist, 0.0)
@@ -59,8 +59,8 @@ func TestFindRoute_EmptyNetwork(t *testing.T) {
 		Edges: map[int64][]models.Edge{},
 	}
 
-	svc := NewRouteService(network)
-	dist, routeNodes, err := svc.FindRoute(0, 0, 1, 1)
+	svc := NewRouteService(network, nil)
+	dist, routeNodes, err := svc.FindRoute(0, 0, 1, 1, nil)
 
 	require.NoError(t, err)
 	require.Less(t, dist, 0.0)
@@ -83,8 +83,8 @@ func TestFindMultipleRoutes_HappyPath(t *testing.T) {
 		},
 	}
 
-	svc := NewRouteService(network)
-	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, 2)
+	svc := NewRouteService(network, nil)
+	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, nil, 2)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
@@ -118,8 +118,8 @@ func TestFindMultipleRoutes_NoRoutesExist(t *testing.T) {
 		},
 	}
 
-	svc := NewRouteService(network)
-	results, err := svc.FindMultipleRoutes(0, 0, 10, 10, 3)
+	svc := NewRouteService(network, nil)
+	results, err := svc.FindMultipleRoutes(0, 0, 10, 10, nil, 3)
 
 	require.NoError(t, err)
 	require.Empty(t, results)
@@ -140,8 +140,8 @@ func TestFindMultipleRoutes_FewerRoutesThanK(t *testing.T) {
 		},
 	}
 
-	svc := NewRouteService(network)
-	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, 5)
+	svc := NewRouteService(network, nil)
+	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, nil, 5)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
@@ -156,8 +156,8 @@ func TestFindMultipleRoutes_EmptyNetwork(t *testing.T) {
 		Edges: map[int64][]models.Edge{},
 	}
 
-	svc := NewRouteService(network)
-	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, 3)
+	svc := NewRouteService(network, nil)
+	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, nil, 3)
 
 	require.NoError(t, err)
 	require.Empty(t, results)
@@ -181,8 +181,8 @@ func TestFindMultipleRoutes_MultipleRoutesOrdering(t *testing.T) {
 		},
 	}
 
-	svc := NewRouteService(network)
-	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, 3)
+	svc := NewRouteService(network, nil)
+	results, err := svc.FindMultipleRoutes(0, 0, 1, 1, nil, 3)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
@@ -206,7 +206,7 @@ func TestNewRouteService(t *testing.T) {
 		Edges: map[int64][]models.Edge{},
 	}
 
-	svc := NewRouteService(network)
+	svc := NewRouteService(network, nil)
 
 	require.NotNil(t, svc)
 	require.Equal(t, network, svc.network)

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -33,6 +33,8 @@
 			isVisible = true;
 			loadReviews(way.id);
 			sidebarLoaded = true;
+
+			console.log(way);
 		}
 	});
 

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -33,8 +33,6 @@
 			isVisible = true;
 			loadReviews(way.id);
 			sidebarLoaded = true;
-
-			console.log(way);
 		}
 	});
 


### PR DESCRIPTION
Review multipliers were previously computed when the network was built. This no longer works when we want to provide personalized routing that gives priority to a user's own reviews. Moves review multipliers to routing time using a MultiplierProvider struct passed into routing methods. This is easily extensible to add further personalization logic beyond reviews. Updates the review multiplier to prioritize a user's own review: if the user has reviewed a way, then only their review is used for the review multiplier with full confidence. If not, review multiplier uses the average rating and is adjusted for confidence based on the number of reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Route recommendations now incorporate user reviews and ratings to favor well-reviewed paths
  * Authenticated users receive personalized routes that prioritize their own reviews on specific routes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->